### PR TITLE
fix(compile): Add "Mutation" in default root level node

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -326,6 +326,17 @@ export enum ${def.name.value} {
             },
           },
         },
+        {
+          kind: gq.Kind.OPERATION_TYPE_DEFINITION,
+          operation: gq.OperationTypeNode.MUTATION,
+          type: {
+            kind: gq.Kind.NAMED_TYPE,
+            name: {
+              kind: gq.Kind.NAME,
+              value: 'Mutation',
+            },
+          },
+        },
       ],
     }
   }


### PR DESCRIPTION
If a schema file does not have a `schema` section defined, then a default `SCHEMA_DEFINITION` is created.

Currently, it only inserts "Query" operation but excludes mutation. As a consequence, even if the schema has mutations defined, exported functions for mutations will not be created when executing `postamble`. 

As a fix, I have added "Mutation" as another default operation.