### PR TITLE
fix(preamble): Don't use "cleanType" for the variable type in query/mutation

### DIFF
--- a/src/preamble.ts
+++ b/src/preamble.ts
@@ -154,7 +154,7 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
                 throw new Error(\`Argument type for \${key} not found\`)
               }
               const cleanType = argTypes[key].replace('[', '').replace(']', '').replace('!', '')
-              return key + ':' + stringifyArgs(val, $InputTypes[cleanType], cleanType)
+              return key + ':' + stringifyArgs(val, $InputTypes[cleanType], argTypes[key])
             })
             .join(',')
         )


### PR DESCRIPTION
GraphQL servers perform variable type checking when a query comes through. Currently, when creating the variables and their types, it's stripping the underlying type to a "cleaned" version. For example, a type of `Int!` will become `Int`, or a type of `[Int]` will become `Int`

The `cleanType` needs to exist to index the `$InputTypes`, but it does not need to replace the original variable type in the underlying query/mutation.

Below is an example of an error that a GraphQL server will return:
```json
{"errors":[{"message":"Variable \"$id\" of type \"Int\" used in position expecting type \"Int!\".",.....}]}
```