### PR TITLE
[Proposal] Read `preamble.ts` during compile instead of storing in a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "typescript": "^4.7.4"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.lib.json",
+    "build": "tsc -p tsconfig.lib.json && npm run copy-base",
+    "copy-base": "cp src/preamble.ts ./dist/preamble.raw.ts",
     "test": "tap test/**/*.test.ts -R spec",
     "test:watch": "tap -w test/**/*.test.ts -R spec",
     "regenerate:big-schema": "swc-node src/index.ts --schema examples/x.graphql --output examples/x.ts",

--- a/src/preamble.ts
+++ b/src/preamble.ts
@@ -1,9 +1,11 @@
-export const Preamble = `
+// Placeholders to keep typescript happy
+type $Atomic = ''
+const $InputTypes: Record<string, any> = {}
+
+/** BASE_HERE **/
+
 import { TypedDocumentNode } from '@graphql-typed-document-node/core'
 import gql from 'graphql-tag'
-
-/* tslint:disable */
-/* eslint-disable */
 
 const VariableName = ' $1fcbcbff-3e78-462f-b45c-668a3e09bfd8'
 const VariableType = ' $1fcbcbff-3e78-462f-b45c-668a3e09bfd9'
@@ -151,7 +153,7 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
           Array.from(Object.entries(args))
             .map(([key, val]) => {
               if (!argTypes[key]) {
-                throw new Error(\`Argument type for \${key} not found\`)
+                throw new Error(`Argument type for ${key} not found`)
               }
               const cleanType = argTypes[key].replace('[', '').replace(']', '').replace('!', '')
               return key + ':' + stringifyArgs(val, $InputTypes[cleanType], cleanType)
@@ -210,5 +212,3 @@ export function fragment<T, Sel extends Selection<T>>(
 ) {
   return selectFn(new GQLType())
 }
-
-`

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -2,6 +2,9 @@
   "extends": "./tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
-    "outDir": "dist"
-  }
+    "outDir": "dist",
+  },
+  "exclude": [
+    "./src/preamble.ts"
+  ],
 }


### PR DESCRIPTION
## Proposal

Instead of storing the preamble contents in a fixed string, I would like to propose having the `preamble.ts` file be copied using `fs.readFile` to improve that file's editing experience. I think this could be solved in a couple of ways, but I wanted to whip up one approach to illustrate what I'm thinking.

Because the preamble is currently stored in a string, the contents are difficult to edit, and IDEs have a hard time figuring out what's happening. 

@spion This is really more of a developer experience improvement, and we get the type checking back in place for that file.

What do you think?

Thanks!