### PR TITLE
fix: top level query arguments

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -210,7 +210,7 @@ export class ${className} extends $Base<"${className}"> {
       return `${field.name.value}<${generics.join(',')}>(${methodArgsSerialized}):$Field<"${
         field.name.value
       }", ${hasSelector ? printTypeWrapped('GetOutput<Sel>', field.type) : printType(field.type)} ${
-        hasArgs ? `, GetVariables<${hasSelector ? 'Sel' : '[]'}, Args>` : ''
+        hasArgs ? `, GetVariables<${hasSelector ? 'Sel' : '[]'}, Args>` : ', GetVariables<Sel>'
       }>`
     }
   }


### PR DESCRIPTION
Addresses Issue #18

The overloaded method definitions excluded the `GetVariables` in the `$Field` type if no arguments were passed. This behavior seemed to short circuit the type inference for lower-level selections.