### PR TITLE
fix: Adds support for variable input types

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -171,7 +171,7 @@ export function compileSchemaString(schemaString: string): string {
 
   function printInputField(def: gq.InputValueDefinitionNode) {
     const maybe = def.type.kind !== gq.Kind.NON_NULL_TYPE ? '?' : ''
-    return `${def.name.value}${maybe}: ${printType(def.type)}`
+    return `${def.name.value}${maybe}: ${printType(def.type)} | Variable<${printType(def.type)}, any>`
   }
 
   function printDocumentation(description?: gq.StringValueNode) {


### PR DESCRIPTION
Fixes #29 

Note: This also seems to make `test-tuple-item-x.bad.ts` pass. I think this is the correct behavior, as you're welcome to use an atomic type as long as it is of the correct typing such as using the select_column enum when satisfying variables.

```ts
import { verify } from './verify'
import { query, $, booking_select_column } from './x.graphql.api'

// cannot use $ if array consistens of atomic types
let bookingsBetween = query(q => [
  q.bookings({ distinct_on: [$('works')] as const }, b => [
    // select fields
    b.bookedAt,
    b.bookerName,
    b.nights,
    b.connection(c => [
      // nested fields
      c.id,
      c.createdAt,
    ]),
  ]),
])

export default [
  verify({
    query: bookingsBetween,
    variables: {
      works: booking_select_column.status
    },
    schemaPath: 'x.graphql',
  }),
]
```