### PR TITLE
feat: support for object, interface and input type extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "scripts": {
     "build": "parcel build",
-    "test": "tap test/**/*.test.ts -R spec",
+    "test": "tap src/**/*.test.ts test/**/*.test.ts -R spec",
+    "test:unit": "tap src/**/*.spec.ts -R spec",
     "test:watch": "tap -w test/**/*.test.ts -R spec",
     "regenerate:big-schema": "swc-node src/cli.ts --schema examples/x.graphql --output examples/x.ts",
     "regenerate:small-schema": "swc-node src/cli.ts --schema examples/zeus.graphql --output examples/zeus.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,11 @@ async function main() {
       describe: 'Additional headers to send to the server if passing a server URL',
       default: [] as string[],
     },
+    schemaExtensions: {
+      type: 'array',
+      describe: 'Additional schemas that extend the base',
+      required: false,
+    },
     output: {
       type: 'string',
       describe: 'The output TypeScript file',

--- a/src/compile.test.ts
+++ b/src/compile.test.ts
@@ -1,0 +1,30 @@
+import t from 'tap'
+import { compileSchemaString } from './compile'
+
+let { describe, it } = t.mocha
+
+let s1 = `
+schema {
+  query: Query
+}
+
+type Query {
+  test(s: String): String
+}
+`
+
+let s2 = `
+extend type Query {
+  other(t: String): Int
+}
+`
+t.autoend(true)
+
+t.test('works with extended schemas', async t => {
+  let res = compileSchemaString(s1, [s2])
+    .split('\n')
+    .filter(l => l.includes('this.$_select'))
+
+  t.match(res[0], '"test"')
+  t.match(res[1], '"other"')
+})

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,10 +1,12 @@
 import * as gq from 'graphql'
 import * as fs from 'fs/promises'
+import * as strcon from 'stream/consumers'
 import { Preamble } from './preamble.lib'
 import { postamble } from './postamble'
 
 import { request } from 'undici'
 import { UserFacingError } from './user-error'
+import { TypeExtensionNode } from 'graphql'
 
 type Args = {
   /**
@@ -48,18 +50,35 @@ async function fetchOrRead(args: Args) {
     })
     let body = await res.body.json()
     if (body.errors) {
-      throw new UserFacingError(`Error introspecting schema from ${args.schema}: ${body.errors}`)
+      throw new UserFacingError(
+        `Error introspecting schema from ${args.schema}: ${JSON.stringify(body.errors, null, 2)}`
+      )
     }
     return gq.printSchema(gq.buildClientSchema(body.data))
+  } else if (args.schema === '') {
+    return await strcon.text(process.stdin)
   } else {
     return await fs.readFile(args.schema, 'utf8')
   }
 }
 
+type SupportedExtensibleNodes =
+  | gq.InterfaceTypeDefinitionNode
+  | gq.ObjectTypeDefinitionNode
+  | gq.InputObjectTypeDefinitionNode
+
+type FieldOf<T extends SupportedExtensibleNodes> = T extends
+  | gq.ObjectTypeDefinitionNode
+  | gq.InterfaceTypeDefinitionNode
+  ? gq.FieldDefinitionNode
+  : T extends gq.InputObjectTypeDefinitionNode
+  ? gq.InputValueDefinitionNode
+  : never
+
 /**
  * Compiles a schema string directly to output TypeScript code
  */
-export function compileSchemaString(schemaString: string): string {
+export function compileSchemaString(schemaString: string, additionalSchemas?: string[]): string {
   let outputScript = ''
   const write = (s: string) => {
     outputScript += s + '\n'
@@ -67,17 +86,39 @@ export function compileSchemaString(schemaString: string): string {
 
   const outputObjectTypeNames = new Set()
 
-  let res = gq.parse(schemaString)
+  let schemas = [gq.parse(schemaString, { noLocation: true })]
 
-  const enumTypes = res.definitions.flatMap(def => {
+  if (additionalSchemas) {
+    for (let extension of additionalSchemas) {
+      let extensionDoc = gq.parse(extension, { noLocation: true })
+      schemas.push(extensionDoc)
+    }
+  }
+
+  let schemaDefinitions = schemas.flatMap(s => s.definitions)
+
+  const enumTypes = schemaDefinitions.flatMap(def => {
     if (def.kind === gq.Kind.ENUM_TYPE_DEFINITION) return [def.name.value]
     return []
   })
 
-  const scalarTypes = res.definitions.flatMap(def => {
+  const scalarTypes = schemaDefinitions.flatMap(def => {
     if (def.kind === gq.Kind.SCALAR_TYPE_DEFINITION) return [def.name.value]
     return []
   })
+
+  const schemaExtensionsMap = schemaDefinitions.filter(gq.isTypeExtensionNode).reduce((acc, el) => {
+    acc.has(el.name.value) ? acc.get(el.name.value)!.push(el) : acc.set(el.name.value, [el])
+    return acc
+  }, new Map<string, gq.TypeExtensionNode[]>())
+
+  function getExtendedFields<T extends SupportedExtensibleNodes>(sd: T) {
+    return ((sd.fields || []) as FieldOf<T>[]).concat(
+      (schemaExtensionsMap.get(sd.name.value) || []).flatMap(
+        n => (n as any).fields || []
+      ) as FieldOf<T>[]
+    )
+  }
 
   const atomicTypes = new Map(
     scalarTypes
@@ -93,7 +134,7 @@ export function compileSchemaString(schemaString: string): string {
   )
 
   const inheritanceMap = new Map(
-    res.definitions.flatMap(def => {
+    schemaDefinitions.flatMap(def => {
       if (def.kind === gq.Kind.OBJECT_TYPE_DEFINITION) {
         return [[def.name.value, def.interfaces?.map(ifc => ifc.name.value)]]
       }
@@ -192,7 +233,9 @@ export class ${className} extends $Base<"${className}"> {
     super("${className}")
   }
 
-  ${def.fields?.map(f => printField(f, className)).join('\n')}
+  ${getExtendedFields(def)
+    .map(f => printField(f, className))
+    .join('\n')}
 }`
   }
 
@@ -293,7 +336,10 @@ export class ${className} extends $Base<"${className}"> {
   constructor() {
     super("${className}")
   }
-  ${def.fields?.map(f => printField(f, className)).join('\n')}
+  ${getExtendedFields(def)
+    .map(f => printField(f, className))
+    .join('\n')}
+
 }`
   }
 
@@ -301,7 +347,9 @@ export class ${className} extends $Base<"${className}"> {
     return `
 ${printDocumentation(def.description)}
 export type ${def.name.value} = {
-  ${def.fields?.map(field => printInputField(field)).join(',\n')}
+  ${getExtendedFields(def)
+    .map(field => printInputField(field))
+    .join(',\n')}
 }
     `
   }
@@ -312,7 +360,9 @@ const $InputTypes: {[key: string]: {[key: string]: string}} = {
   ${defs
     .map(
       def => `  ${def.name.value}: {
-    ${def.fields?.map(field => `${field.name.value}: "${printTypeGql(field.type)}"`).join(',\n')}
+    ${getExtendedFields(def)
+      .map(field => `${field.name.value}: "${printTypeGql(field.type)}"`)
+      .join(',\n')}
   }`
     )
     .join(',\n')}
@@ -376,7 +426,8 @@ export enum ${def.name.value} {
   write(printEnumList())
 
   let rootNode: gq.SchemaDefinitionNode | null = null
-  for (let def of res.definitions) {
+
+  for (let def of schemaDefinitions) {
     switch (def.kind) {
       case gq.Kind.OBJECT_TYPE_DEFINITION:
         write(printObjectType(def))
@@ -444,7 +495,7 @@ export enum ${def.name.value} {
   write(postamble(rootNode.operationTypes.map(o => o.operation.toString())))
   write(
     printInputTypeMap(
-      res.definitions.filter(def => def.kind === gq.Kind.INPUT_OBJECT_TYPE_DEFINITION) as any[]
+      schemaDefinitions.filter(def => def.kind === gq.Kind.INPUT_OBJECT_TYPE_DEFINITION) as any[]
     )
   )
 


### PR DESCRIPTION
Addresses https://github.com/typed-graphql-builder/typed-graphql-builder/issues/25

I'm not entirely sure about the API

# Option 1: Extra files

```
typed-graphql-builder --schema schemafile.gql --schemaExtensions ext1.gql --schemaExtensions ext2.gql ...
```

Cons: tedious to specify if lots of files

# Option 2: Option 1 + globs

Cons: need extra logic to auto-exclude original schema from globs

# Option 3: (works in the PR): stdin

Simply concatenate all your `gql` files and pass them to the tool :sweat_smile: 

```
cat src/**/*.gql | npx typed-grapql-builder --schema - --output - > api.ts
```

