### PR TITLE
feat: Customizable scalars

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "swc-node": "^1.0.0",
     "tap": "^16.3.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.2",
+    "typescript": "~4.7.0",
     "util": "^0.12.4"
   },
   "scripts": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,12 @@ async function main() {
       describe: 'The output TypeScript file',
       required: true,
     },
+    scalar: {
+      type: 'array',
+      string: true,
+      describe:
+        'List of scalars in the format ScalarName=[./path/to/scalardefinition#ScalarExport]',
+    },
   }).argv
 
   try {

--- a/src/compile.test.ts
+++ b/src/compile.test.ts
@@ -1,12 +1,15 @@
 import t from 'tap'
 import { compileSchemas } from './compile'
 
+// ------------------------------------------------------------------------------
+
 let s1 = `
 schema {
   query: Query
 }
 
 type Query {
+  a(s: String): String
   test(s: String): String
 }
 `
@@ -14,15 +17,37 @@ type Query {
 let s2 = `
 extend type Query {
   other(t: String): Int
+  a(s: String): Int
 }
 `
-t.autoend(true)
 
 t.test('works with extended schemas', async t => {
-  let res = compileSchemas([s1, s2])
-    .split('\n')
-    .filter(l => l.includes('this.$_select'))
+  let code = compileSchemas([s1, s2])
 
-  t.match(res[0], '"test"')
+  let res = code.split('\n').filter(l => l.includes('this.$_select'))
+
+  // Sorted alphabetically and contains only one occurrence of "a"
+  t.match(res[0], '"a"')
   t.match(res[1], '"other"')
+  t.match(res[2], '"test"')
+})
+
+// ------------------------------------------------------------------------------
+
+let schemaScalars = `
+scalar A
+scalar B
+
+type Query {
+  test(s: String): A
+}
+`
+t.test('works with custom scalars', async t => {
+  let res = compileSchemas([schemaScalars], {
+    scalars: [['(.+)', './scalars#$1']],
+  })
+
+  let importList = res.split('\n').filter(l => l.startsWith('import') && l.includes('scalars'))
+
+  t.same(importList, [`import type { A } from './scalars'`, `import type { B } from './scalars'`])
 })

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -2,13 +2,12 @@ import * as gq from 'graphql'
 import * as fs from 'fs/promises'
 import { Preamble } from './preamble.lib'
 import { postamble } from './postamble'
-
 import { request } from 'undici'
 import { UserFacingError } from './user-error'
 import { glob } from 'glob'
 import { getScalars } from './scalars'
 
-type Args = {
+export type Args = {
   /**
    * The schema(s) to compile. Can be a path to a file or an URL to a server with introspection
    */
@@ -94,7 +93,7 @@ type FieldOf<T extends SupportedExtensibleNodes> = T extends
   ? gq.InputValueDefinitionNode
   : never
 
-type Options = {
+export type Options = {
   scalars?: [string, string][]
 }
 
@@ -114,10 +113,7 @@ export function compileSchemas(schemaStrings: string | string[], options: Option
 /**
  * Compile a list of schema definitions with the specified options into an output script string
  */
-export function compileSchemaDefinitions(
-  schemaDefinitions: gq.DefinitionNode[],
-  options: Options = {}
-) {
+function compileSchemaDefinitions(schemaDefinitions: gq.DefinitionNode[], options: Options = {}) {
   let outputScript = ''
   const write = (s: string) => {
     outputScript += s + '\n'

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,4 +1,5 @@
 import * as gq from 'graphql'
+import type { DefinitionNode } from 'graphql'
 import * as fs from 'fs/promises'
 import { Preamble } from './preamble.lib'
 import { postamble } from './postamble'
@@ -113,7 +114,10 @@ export function compileSchemas(schemaStrings: string | string[], options: Option
 /**
  * Compile a list of schema definitions with the specified options into an output script string
  */
-function compileSchemaDefinitions(schemaDefinitions: gq.DefinitionNode[], options: Options = {}) {
+export function compileSchemaDefinitions(
+  schemaDefinitions: DefinitionNode[],
+  options: Options = {}
+) {
   let outputScript = ''
   const write = (s: string) => {
     outputScript += s + '\n'

--- a/src/scalars.test.ts
+++ b/src/scalars.test.ts
@@ -1,0 +1,34 @@
+import t from 'tap'
+import { getScalars } from './scalars'
+
+let scalarMapPairs = [
+  ['Empty', ''],
+  ['MyTest', 'string'],
+  ['Another', './path/to/x#TypeName'],
+  ['JSON(.+)', './jsons#JSON$1'],
+  ['.+', 'unknown'],
+] as [string, string][]
+
+t.test('plain string scalar', async t => {
+  let scalarInfo = getScalars(['MyTest'], scalarMapPairs)
+  t.same(scalarInfo.map, [['MyTest', 'string']])
+  t.same(scalarInfo.imports, [])
+})
+
+t.test('scalar with import', async t => {
+  let scalarInfo = getScalars(['Another'], scalarMapPairs)
+  t.same(scalarInfo.map, [['Another', 'Another']])
+  t.same(scalarInfo.imports, [`import type { TypeName as Another } from './path/to/x'`])
+})
+
+t.test('scalar with import and pattern', async t => {
+  let scalarInfo = getScalars(['JSONTextDocument'], scalarMapPairs)
+  t.same(scalarInfo.map, [['JSONTextDocument', 'JSONTextDocument']])
+  t.same(scalarInfo.imports, [`import type { JSONTextDocument } from './jsons'`])
+})
+
+t.test('scalar not matching any other pattern', async t => {
+  let scalarInfo = getScalars(['Blaha'], scalarMapPairs)
+  t.same(scalarInfo.map, [['Blaha', 'unknown']])
+  t.same(scalarInfo.imports, [])
+})

--- a/src/scalars.ts
+++ b/src/scalars.ts
@@ -1,0 +1,58 @@
+// Default to string for all other scalars
+const DEFAULT_SCALAR_MAPPING = [['.+', 'string']] as [string, string][]
+
+type ScalarMapping = {
+  nameRegex: string
+  typePathPattern: string
+}
+
+type ResolvedScalar = {
+  name: string
+  importStatement?: string
+  resolvedType: string
+}
+
+function pairsToScalarMap(scalarArgs?: [string, string][]): ScalarMapping[] {
+  return (scalarArgs || DEFAULT_SCALAR_MAPPING).map(([nameRegex, typePathPattern]) => ({
+    nameRegex,
+    typePathPattern: typePathPattern ?? nameRegex,
+  }))
+}
+
+function resolveFromPattern(scalarMap: ScalarMapping[], scalar: string): ResolvedScalar {
+  for (let { nameRegex: regex, typePathPattern } of scalarMap) {
+    let m = scalar.match(regex)
+    if (scalar.match(regex)) {
+      let resolvedTypePath = scalar.replace(new RegExp(regex), typePathPattern)
+      return resolveFromTypePath(scalar, resolvedTypePath)
+    }
+  }
+
+  return { resolvedType: 'unknown', name: scalar, importStatement: undefined }
+}
+
+function resolveFromTypePath(name: string, typePath: string) {
+  let [importFile, importName] = typePath.split('#')
+  if (!importName) {
+    importName = importFile
+    importFile = ''
+  }
+
+  let importStatement = importFile
+    ? `import type { ${
+        importName !== name ? `${importName} as ${name}` : importName
+      } } from '${importFile}'`
+    : undefined
+
+  return { name, resolvedType: importStatement ? name : importName, importStatement }
+}
+
+export function getScalars(scalars: string[], scalarMapPairs?: [string, string][]) {
+  let scalarMap = pairsToScalarMap(scalarMapPairs)
+  let scalarInfo = scalars.map(s => resolveFromPattern(scalarMap, s))
+
+  let map = scalarInfo.map(si => [si.name, si.resolvedType] as [string, string])
+  let imports = scalarInfo.flatMap(si => (si.importStatement ? [si.importStatement] : []))
+
+  return { map, imports }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3803,10 +3803,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
-  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
+typescript@~4.7.0:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR implements customization options for scalars.


## New export

The export `compileSchemaDefinitions(defs, options)` should make it easier to integrate with graphql codegen

Currently the options only include a list of scalar patterns (a tuple containing a scalar name and a scalar value)

## Configure scalars

Scalars can be passed via the CLI via

--scalar ScalarNamePattern=ScalarTypePattern

In the base case, this allows users to map scalars to an existing type, e.g.

```
--scalar jsonb=unknown
```

Like in the typescript type generator in graphql-codegen, an import path is allowed

```
--scalar MyScalar=./path/to/some-file#ImportedType
```

which will yield

```typescript                                                                                              
import type { ImportedType } from './path/to/some-file'                                                    
```                                                                                                        
                                                                                                           
This feature goes a bit further, allowing generic regex patterns:                                          
                                                                                                           
                                                                                                           
```                                                                                                        
--scalar 'JSON(.+)=./jsons#JSON$1'                                                                         
```                                                                                                        
                                                                                                           
will map a `JSONDocument` scalar to                                                                        
                                                                                                           
```typescript                                                                                              
import type { JSONDocument } from './jsons'                                                                
```                                                                                                        
                                                                                                           
and at the same time map a scalar `JSONParagraph` to                                                       
                                                                                                           
```typescript                                                                                              
import type { JSONParagraph } from './jsons'                                                               
```                                                                                                        