### PR TITLE
fix: Fixes unhandled exception caused by null as a valid argument

### DIFF
--- a/examples/api-sw.ts
+++ b/examples/api-sw.ts
@@ -213,6 +213,7 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
       case 'boolean':
         return JSON.stringify(args)
       default:
+        if (args == null) return 'null'
         if (VariableName in (args as any)) {
           if (!argVarType) throw new Error('Cannot use variabe as sole unnamed field argument')
           const variable = args as Variable<any, any>
@@ -222,7 +223,6 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
         }
         if (Array.isArray(args))
           return '[' + args.map(arg => stringifyArgs(arg, argTypes, argVarType)).join(',') + ']'
-        if (args == null) return 'null'
         const wrapped = (content: string) => (argVarType ? '{' + content + '}' : content)
         return wrapped(
           Array.from(Object.entries(args))

--- a/examples/countries-schema.ts
+++ b/examples/countries-schema.ts
@@ -213,6 +213,7 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
       case 'boolean':
         return JSON.stringify(args)
       default:
+        if (args == null) return 'null'
         if (VariableName in (args as any)) {
           if (!argVarType) throw new Error('Cannot use variabe as sole unnamed field argument')
           const variable = args as Variable<any, any>
@@ -222,7 +223,6 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
         }
         if (Array.isArray(args))
           return '[' + args.map(arg => stringifyArgs(arg, argTypes, argVarType)).join(',') + ']'
-        if (args == null) return 'null'
         const wrapped = (content: string) => (argVarType ? '{' + content + '}' : content)
         return wrapped(
           Array.from(Object.entries(args))

--- a/examples/x.ts
+++ b/examples/x.ts
@@ -213,6 +213,7 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
       case 'boolean':
         return JSON.stringify(args)
       default:
+        if (args == null) return 'null'
         if (VariableName in (args as any)) {
           if (!argVarType) throw new Error('Cannot use variabe as sole unnamed field argument')
           const variable = args as Variable<any, any>
@@ -222,7 +223,6 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
         }
         if (Array.isArray(args))
           return '[' + args.map(arg => stringifyArgs(arg, argTypes, argVarType)).join(',') + ']'
-        if (args == null) return 'null'
         const wrapped = (content: string) => (argVarType ? '{' + content + '}' : content)
         return wrapped(
           Array.from(Object.entries(args))

--- a/examples/zeus.ts
+++ b/examples/zeus.ts
@@ -213,6 +213,7 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
       case 'boolean':
         return JSON.stringify(args)
       default:
+        if (args == null) return 'null'
         if (VariableName in (args as any)) {
           if (!argVarType) throw new Error('Cannot use variabe as sole unnamed field argument')
           const variable = args as Variable<any, any>
@@ -222,7 +223,6 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
         }
         if (Array.isArray(args))
           return '[' + args.map(arg => stringifyArgs(arg, argTypes, argVarType)).join(',') + ']'
-        if (args == null) return 'null'
         const wrapped = (content: string) => (argVarType ? '{' + content + '}' : content)
         return wrapped(
           Array.from(Object.entries(args))

--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -216,6 +216,7 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
       case 'boolean':
         return JSON.stringify(args)
       default:
+        if (args == null) return 'null'
         if (VariableName in (args as any)) {
           if (!argVarType) throw new Error('Cannot use variabe as sole unnamed field argument')
           const variable = args as Variable<any, any>
@@ -225,7 +226,6 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
         }
         if (Array.isArray(args))
           return '[' + args.map(arg => stringifyArgs(arg, argTypes, argVarType)).join(',') + ']'
-        if (args == null) return 'null'
         const wrapped = (content: string) => (argVarType ? '{' + content + '}' : content)
         return wrapped(
           Array.from(Object.entries(args))

--- a/test/examples/test-x.good.ts
+++ b/test/examples/test-x.good.ts
@@ -74,6 +74,24 @@ let orderByTestString = `query ($myvar: order_by!, $optional: order_by) {
   }
 }`
 
+const nullableArgument = mutation(m => [
+  m.updateBooking(
+    {
+      pk_columns: { id: $$('id') },
+      _set: {
+        bookedAt: null,
+      },
+    },
+    r => [r.id]
+  ),
+])
+
+const nullableArgumentString = `mutation ($id: uuid!) {
+  updateBooking(pk_columns: {id: $id}, _set: {bookedAt: null}) {
+    id
+  }
+}`
+
 export default [
   verify({
     query: orderByTest,
@@ -95,5 +113,13 @@ export default [
     query: upsertBookingChannelMutation,
     variables: { bc: { name: 'hello' } },
     schemaPath: 'x.graphql',
+  }),
+  verify({
+    query: nullableArgument,
+    variables: {
+      id: 'abc',
+    },
+    schemaPath: 'x.graphql',
+    string: nullableArgumentString,
   }),
 ]


### PR DESCRIPTION
Fixes #40 

Includes a new test case on test-x.good.ts which uses the Hasura API where nulls can frequently be used as arguments to `_set`. Examples regenerated.