### PR TITLE
fix: tighten strictness

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -304,7 +304,6 @@ export class ${className} extends $Base<"${className}"> {
       methodArgs.push(`selectorFn: (s: ${fieldTypeName}) => [...Sel]`)
     }
     if (methodArgs.length > 0) {
-      let extractArgs = ''
       let methodArgsSerialized = methodArgs.join(', ')
       const argsType = `{
         ${(field.arguments ?? []).map(arg => printInputField(arg)).join('\n')},
@@ -322,7 +321,7 @@ export class ${className} extends $Base<"${className}"> {
       throw new Error('Attempting to generate function field definition for non-function field')
     }
   }
-  function printField(field: gq.FieldDefinitionNode, parentName: string) {
+  function printField(field: gq.FieldDefinitionNode, _parentName: string) {
     const fieldTypeName = printTypeBase(field.type)
 
     let hasArgs = !!field.arguments?.length,

--- a/src/preamble.lib.ts
+++ b/src/preamble.lib.ts
@@ -2,4 +2,4 @@ import * as fs from 'fs'
 
 export const Preamble = fs
   .readFileSync(__dirname + '/preamble.src.ts', 'utf8')
-  .split('/* BEGIN PREAMBLE */')[1]
+  .split('/* BEGIN PREAMBLE */')[1]!

--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -1,5 +1,5 @@
 type $Atomic = string
-let $InputTypes: { [key: string]: any } = {}
+let $InputTypes: { [key: string]: { [key: string]: string } } = {}
 let $Enums = new Set()
 
 /* BEGIN PREAMBLE */
@@ -13,8 +13,10 @@ const VariableName = ' $1fcbcbff-3e78-462f-b45c-668a3e09bfd8'
 
 class Variable<T, Name extends string> {
   private [VariableName]: Name
+  // @ts-ignore
   private _type?: T
 
+  // @ts-ignore
   constructor(name: Name, private readonly isRequired?: boolean) {
     this[VariableName] = name
   }
@@ -79,6 +81,7 @@ class $Field<Name extends string, Type, Vars = {}> {
 }
 
 class $Base<Name extends string> {
+  // @ts-ignore
   constructor(private $$name: Name) {}
 
   protected $_select<Key extends string>(
@@ -89,8 +92,11 @@ class $Base<Name extends string> {
   }
 }
 
+// @ts-ignore
 class $Union<T, Name extends String> {
+  // @ts-ignore
   private type!: T
+  // @ts-ignore
   private name!: Name
 
   constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }) {}
@@ -104,8 +110,11 @@ class $Union<T, Name extends String> {
   }
 }
 
+// @ts-ignore
 class $Interface<T, Name extends string> extends $Base<Name> {
+  // @ts-ignore
   private type!: T
+  // @ts-ignore
   private name!: Name
 
   constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
@@ -123,6 +132,7 @@ class $Interface<T, Name extends string> extends $Base<Name> {
 
 class $UnionSelection<T, Vars> {
   public kind: 'union' = 'union'
+  // @ts-ignore
   private vars!: Vars
   constructor(public alternativeName: string, public alternativeSelection: Selection<T>) {}
 }
@@ -189,7 +199,7 @@ function getArgVarType(input: string): ArgVarType {
       }
     : null
 
-  const type = array ? arrRegex.exec(input)![1] : input
+  const type = array ? arrRegex.exec(input)![1]! : input
   const isRequired = type.endsWith('!')
 
   return {
@@ -230,12 +240,15 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
         return wrapped(
           Array.from(Object.entries(args))
             .map(([key, val]) => {
-              if (!argTypes[key]) {
+              let argTypeForKey = argTypes[key]
+              if (!argTypeForKey) {
                 throw new Error(`Argument type for ${key} not found`)
               }
-              const cleanType = argTypes[key].replace('[', '').replace(']', '').replace('!', '')
+              const cleanType = argTypeForKey.replace('[', '').replace(']', '').replace('!', '')
               return (
-                key + ':' + stringifyArgs(val, $InputTypes[cleanType], getArgVarType(argTypes[key]))
+                key +
+                ':' +
+                stringifyArgs(val, $InputTypes[cleanType]!, getArgVarType(argTypeForKey))
               )
             })
             .join(',')

--- a/src/scalars.ts
+++ b/src/scalars.ts
@@ -21,7 +21,6 @@ function pairsToScalarMap(scalarArgs?: [string, string][]): ScalarMapping[] {
 
 function resolveFromPattern(scalarMap: ScalarMapping[], scalar: string): ResolvedScalar {
   for (let { nameRegex: regex, typePathPattern } of scalarMap) {
-    let m = scalar.match(regex)
     if (scalar.match(regex)) {
       let resolvedTypePath = scalar.replace(new RegExp(regex), typePathPattern)
       return resolveFromTypePath(scalar, resolvedTypePath)
@@ -44,7 +43,7 @@ function resolveFromTypePath(name: string, typePath: string) {
       } } from '${importFile}'`
     : undefined
 
-  return { name, resolvedType: importStatement ? name : importName, importStatement }
+  return { name, resolvedType: importStatement ? name : importName!, importStatement }
 }
 
 export function getScalars(scalars: string[], scalarMapPairs?: [string, string][]) {

--- a/test/examples/test-x.good.ts
+++ b/test/examples/test-x.good.ts
@@ -96,6 +96,7 @@ export default [
   verify({
     query: orderByTest,
     schemaPath: 'x.graphql',
+    string: orderByTestString,
     variables: {
       myvar: order_by.asc_nulls_first,
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,6 +76,9 @@
 
     /* Type Checking */
     "strict": true /* Enable all strict type-checking options. */,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
     "noImplicitReturns": true
   }


### PR DESCRIPTION
This PR tightens the strictness for the generated code and adds a few ignore hints here and there in places where the compiler doesn't understand the reason for unused variable placement, in the hopes of making it cause less interference in projects.

Fixes https://github.com/typed-graphql-builder/typed-graphql-builder/issues/44
