### PR TITLE
feat: add typename and interface fields

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,11 @@ async function main() {
       describe:
         'List of scalars in the format ScalarName=[./path/to/scalardefinition#ScalarExport]',
     },
+    includeTypename: {
+      type: 'boolean',
+      boolean: true,
+      describe: 'Include the __typename field in all objects',
+    },
   }).argv
 
   try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ async function main() {
     includeTypename: {
       type: 'boolean',
       boolean: true,
+      default: false,
       describe: 'Include the __typename field in all objects',
     },
   }).argv

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -161,10 +161,8 @@ export function compileSchemaDefinitions(
       f1.name.value < f2.name.value ? -1 : f1.name.value > f2.name.value ? 1 : 0
     )
 
-    if (options.includeTypename) {
+    if (options.includeTypename && sd.kind != gq.Kind.INTERFACE_TYPE_DEFINITION) {
       fieldList.push({
-        // kind: gq.Kind.FIELD,
-        // name:
         kind: gq.Kind.FIELD_DEFINITION,
         name: { kind: gq.Kind.NAME, value: '__typename' },
         type: { kind: gq.Kind.NAMED_TYPE, name: { value: 'String', kind: gq.Kind.NAME } },

--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -330,13 +330,13 @@ export type OutputTypeOf<T> = T extends $Base<any>
   ? OutputTypeOf<Inner>
   : never
 
-export type TypedDocumentOutput<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
+export type QueryOutputType<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
   infer Out
 >
   ? Out
   : never
 
-export type TypedDocumentInput<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
+export type QueryInputType<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
   any,
   infer In
 >

--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -93,13 +93,16 @@ class $Base<Name extends string> {
 }
 
 // @ts-ignore
-class $Union<T, Name extends String> {
+class $Union<T, Name extends String> extends $Base<Name> {
   // @ts-ignore
-  private type!: T
+  private $$type!: T
   // @ts-ignore
-  private name!: Name
+  private $$name!: Name
 
-  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }) {}
+  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
+    super($$name)
+  }
+
   $on<Type extends keyof T, Sel extends Selection<T[Type]>>(
     alternative: Type,
     selectorFn: (selector: T[Type]) => [...Sel]
@@ -113,9 +116,9 @@ class $Union<T, Name extends String> {
 // @ts-ignore
 class $Interface<T, Name extends string> extends $Base<Name> {
   // @ts-ignore
-  private type!: T
+  private $$type!: T
   // @ts-ignore
-  private name!: Name
+  private $$name!: Name
 
   constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
     super($$name)
@@ -325,6 +328,19 @@ export type OutputTypeOf<T> = T extends $Base<any>
   ? OutputTypeOf<Inner>
   : [T] extends [(args: any, selFn: (arg: infer Inner) => any) => any]
   ? OutputTypeOf<Inner>
+  : never
+
+export type TypedDocumentOutput<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
+  infer Out
+>
+  ? Out
+  : never
+
+export type TypedDocumentInput<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
+  any,
+  infer In
+>
+  ? In
   : never
 
 export function fragment<T, Sel extends Selection<T>>(

--- a/test/examples/test-sw.good.ts
+++ b/test/examples/test-sw.good.ts
@@ -1,4 +1,4 @@
-import { query, $, TypedDocumentOutput } from './sw.graphql.api'
+import { query, $, QueryOutputType } from './sw.graphql.api'
 import { verify } from './verify'
 
 let planetQuery = query(q => [
@@ -47,9 +47,19 @@ const multiChoiceQuery = query(q => [
   ]),
 ])
 
-type PersonOrPlanet = TypedDocumentOutput<typeof multiChoiceQuery>
+type PersonOrPlanet = QueryOutputType<typeof multiChoiceQuery>
 
 declare let v: PersonOrPlanet
+
+export function test() {
+  let personOrPlanet = v.node!
+  switch (personOrPlanet.__typename) {
+    case 'Person':
+      return personOrPlanet.birthYear
+    case 'Planet':
+      return personOrPlanet.climates?.toString()
+  }
+}
 
 export default [
   verify({

--- a/test/examples/test-sw.good.ts
+++ b/test/examples/test-sw.good.ts
@@ -1,4 +1,4 @@
-import { query, $ } from './sw.graphql.api'
+import { query, $, TypedDocumentOutput } from './sw.graphql.api'
 import { verify } from './verify'
 
 let planetQuery = query(q => [
@@ -38,6 +38,18 @@ const nodeQueryString = `query {
     }
   }
 }`
+
+const multiChoiceQuery = query(q => [
+  q.node({ id: 'x' }, n => [
+    n.id,
+    n.$on('Person', p => [p.birthYear, p.__typename]),
+    n.$on('Planet', p => [p.climates, p.__typename]),
+  ]),
+])
+
+type PersonOrPlanet = TypedDocumentOutput<typeof multiChoiceQuery>
+
+declare let v: PersonOrPlanet
 
 export default [
   verify({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -69,6 +69,7 @@ for (let schema of glob.sync(`./examples/*.graphql`, { cwd: __dirname })) {
       await compile({
         schema: path.join(__dirname, schema),
         output: path.join(__dirname, 'examples', `${schemaName}.api.ts`),
+        includeTypename: true,
       })
     })
 
@@ -106,7 +107,7 @@ for (let schema of glob.sync(`./examples/*.graphql`, { cwd: __dirname })) {
       t.test(`compile fails with example ${exampleName}`, async t => {
         let res = compileTs(example)
         if (res.status) {
-          t.pass('failed to compile ' + res.stdout)
+          t.pass('failed to compile ' + res.stdout.toString().substring(0, 255))
         } else {
           t.fail('bad example compiled with no errors')
         }


### PR DESCRIPTION
This PR adds several options that make working with unions/interfaces easier



- Add `--includeTypename` argument to include `__typename` to all output types. This should make it easier to write queries for discriminated unions and interfaces. Note that the typename must be included in every object separately, e.g.
  ```typescript
  let addToCartMutation = mutation(m => [m.addToCart({itemId: $('id')}, res => [
    res.message,
    res.$on('Success', s => [s.__typename]),
    res.$on('MissingItemError', s => [s.__typename]),
    res.$on('InsufficientQuantityError', s => [s.__typename, s.remaining]),
  ])])

  function MyComponent() { 
    let addToCart = useMutation(addToCartMutation)
    let handler = async (id) => {
      let res = (await addToCart({id})).addToCart;
      switch (res.__typename) {
        case 'Success': return `handle success ${res.message}`;
        case 'MissingItemError': return `handle missing item: ${res.message}`
        case 'InsufficientQuantityError': return `handle insufficient quantity of ${res.remaining}`;
      }
    }
    return <ui>...</ui>
  }
  ```

- Common fields in interfaces are now available at the toplevel interface type, so they don't have to be included in `$on` calls. See `message` in the above example. Note that this exlcudes the new `__typename` addition for now - while it can be added, it will unfortunately not be useful for discriminating between the types if added at the toplevel interface type.

- Add `QueryOutputType` and `QueryInputType` to make it easier to declare the types of a query
  ```typescript
  import {query, QueryOutputType} from './my.api.ts';
  let userQuery = query(q => [q.user({id: value}, m => [m.id, m.name])])
  let MyPartialUser = QueryOutputType<typeof userQuery> // {id: string, name: string}
  ```