### PR TITLE
feat: simplify input and output types

### DIFF
--- a/src/postamble.ts
+++ b/src/postamble.ts
@@ -8,7 +8,7 @@ export function ${op}<Sel extends Selection<$RootTypes.${op}>>(
 ): TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
 export function ${op}<Sel extends Selection<$RootTypes.${op}>>(
   selectFn: (q: $RootTypes.${op}) => [...Sel]
-): TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+): TypedDocumentNode<GetOutput<Sel>, Simplify<GetVariables<Sel>>>
 export function ${op}<Sel extends Selection<$RootTypes.query>>(name: any, selectFn?: any) {
   if (!selectFn) {
     selectFn = name


### PR DESCRIPTION
Simplifies input and output types of the resulting `TypedDocumentNode`

Prior art: https://github.com/koskimas/kysely/blob/a8e28d9edd6284d5410f93bc24d3c6252add6ea1/src/util/type-utils.ts#L141


Before

![image](https://user-images.githubusercontent.com/502412/223389027-ad90a56f-e9e1-41c1-887f-e33950f09a9a.png)


After

![image](https://user-images.githubusercontent.com/502412/223388829-1443569a-c9fb-48ba-b632-b09b95eaf067.png)
