### PR TITLE
fix: allow building with Vite

### DIFF
--- a/examples/api-sw.ts
+++ b/examples/api-sw.ts
@@ -1,6 +1,6 @@
 
 
-import { TypedDocumentNode } from '@graphql-typed-document-node/core'
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
 import { gql } from 'graphql-tag'
 
 /* tslint:disable */
@@ -10,8 +10,10 @@ const VariableName = ' $1fcbcbff-3e78-462f-b45c-668a3e09bfd8'
 
 class Variable<T, Name extends string> {
   private [VariableName]: Name
+  // @ts-ignore
   private _type?: T
 
+  // @ts-ignore
   constructor(name: Name, private readonly isRequired?: boolean) {
     this[VariableName] = name
   }
@@ -76,6 +78,7 @@ class $Field<Name extends string, Type, Vars = {}> {
 }
 
 class $Base<Name extends string> {
+  // @ts-ignore
   constructor(private $$name: Name) {}
 
   protected $_select<Key extends string>(
@@ -86,11 +89,17 @@ class $Base<Name extends string> {
   }
 }
 
-class $Union<T, Name extends String> {
-  private type!: T
-  private name!: Name
+// @ts-ignore
+class $Union<T, Name extends String> extends $Base<Name> {
+  // @ts-ignore
+  private $$type!: T
+  // @ts-ignore
+  private $$name!: Name
 
-  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }) {}
+  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
+    super($$name)
+  }
+
   $on<Type extends keyof T, Sel extends Selection<T[Type]>>(
     alternative: Type,
     selectorFn: (selector: T[Type]) => [...Sel]
@@ -101,9 +110,12 @@ class $Union<T, Name extends String> {
   }
 }
 
+// @ts-ignore
 class $Interface<T, Name extends string> extends $Base<Name> {
-  private type!: T
-  private name!: Name
+  // @ts-ignore
+  private $$type!: T
+  // @ts-ignore
+  private $$name!: Name
 
   constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
     super($$name)
@@ -120,6 +132,7 @@ class $Interface<T, Name extends string> extends $Base<Name> {
 
 class $UnionSelection<T, Vars> {
   public kind: 'union' = 'union'
+  // @ts-ignore
   private vars!: Vars
   constructor(public alternativeName: string, public alternativeSelection: Selection<T>) {}
 }
@@ -128,16 +141,22 @@ type Selection<_any> = ReadonlyArray<$Field<any, any, any> | $UnionSelection<any
 
 type NeverNever<T> = [T] extends [never] ? {} : T
 
-export type GetOutput<X extends Selection<any>> = UnionToIntersection<
-  {
-    [I in keyof X]: X[I] extends $Field<infer Name, infer Type, any> ? { [K in Name]: Type } : never
-  }[keyof X & number]
-> &
-  NeverNever<
+type Simplify<T> = { [K in keyof T]: T[K] } & {}
+
+export type GetOutput<X extends Selection<any>> = Simplify<
+  UnionToIntersection<
     {
-      [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? Type : never
+      [I in keyof X]: X[I] extends $Field<infer Name, infer Type, any>
+        ? { [K in Name]: Type }
+        : never
     }[keyof X & number]
-  >
+  > &
+    NeverNever<
+      {
+        [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? Type : never
+      }[keyof X & number]
+    >
+>
 
 type PossiblyOptionalVar<VName extends string, VType> = undefined extends VType
   ? { [key in VName]?: VType }
@@ -186,7 +205,7 @@ function getArgVarType(input: string): ArgVarType {
       }
     : null
 
-  const type = array ? arrRegex.exec(input)![1] : input
+  const type = array ? arrRegex.exec(input)![1]! : input
   const isRequired = type.endsWith('!')
 
   return {
@@ -227,12 +246,15 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
         return wrapped(
           Array.from(Object.entries(args))
             .map(([key, val]) => {
-              if (!argTypes[key]) {
+              let argTypeForKey = argTypes[key]
+              if (!argTypeForKey) {
                 throw new Error(`Argument type for ${key} not found`)
               }
-              const cleanType = argTypes[key].replace('[', '').replace(']', '').replace('!', '')
+              const cleanType = argTypeForKey.replace('[', '').replace(']', '').replace(/!/g, '')
               return (
-                key + ':' + stringifyArgs(val, $InputTypes[cleanType], getArgVarType(argTypes[key]))
+                key +
+                ':' +
+                stringifyArgs(val, $InputTypes[cleanType]!, getArgVarType(argTypeForKey))
               )
             })
             .join(',')
@@ -309,6 +331,19 @@ export type OutputTypeOf<T> = T extends $Base<any>
   ? OutputTypeOf<Inner>
   : [T] extends [(args: any, selFn: (arg: infer Inner) => any) => any]
   ? OutputTypeOf<Inner>
+  : never
+
+export type QueryOutputType<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
+  infer Out
+>
+  ? Out
+  : never
+
+export type QueryInputType<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
+  any,
+  infer In
+>
+  ? In
   : never
 
 export function fragment<T, Sel extends Selection<T>>(
@@ -1204,6 +1239,14 @@ export class Node extends $Interface<{Film: Film,Person: Person,Planet: Planet,S
   constructor() {
     super({Film: Film,Person: Person,Planet: Planet,Species: Species,Starship: Starship,Vehicle: Vehicle}, "Node")
   }
+  
+      
+/**
+ * The id of the object.
+ */
+      get id(): $Field<"id", string>  {
+       return this.$_select("id") as any
+      }
 }
 
 
@@ -4268,14 +4311,23 @@ export class VehiclesEdge extends $Base<"VehiclesEdge"> {
   
 
 export function query<Sel extends Selection<$RootTypes.query>>(
+  name: string,
   selectFn: (q: $RootTypes.query) => [...Sel]
-) {
+): TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+export function query<Sel extends Selection<$RootTypes.query>>(
+  selectFn: (q: $RootTypes.query) => [...Sel]
+): TypedDocumentNode<GetOutput<Sel>, Simplify<GetVariables<Sel>>>
+export function query<Sel extends Selection<$RootTypes.query>>(name: any, selectFn?: any) {
+  if (!selectFn) {
+    selectFn = name
+    name = ''
+  }
   let field = new $Field<'query', GetOutput<Sel>, GetVariables<Sel>>('query', {
     selection: selectFn(new $Root.query()),
   })
-  const str = fieldToQuery('query', field)
+  const str = fieldToQuery(`query ${name}`, field)
 
-  return gql(str) as any as TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+  return gql(str) as any
 }
 
 

--- a/examples/x.ts
+++ b/examples/x.ts
@@ -1,6 +1,6 @@
 
 
-import { TypedDocumentNode } from '@graphql-typed-document-node/core'
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
 import { gql } from 'graphql-tag'
 
 /* tslint:disable */
@@ -10,8 +10,10 @@ const VariableName = ' $1fcbcbff-3e78-462f-b45c-668a3e09bfd8'
 
 class Variable<T, Name extends string> {
   private [VariableName]: Name
+  // @ts-ignore
   private _type?: T
 
+  // @ts-ignore
   constructor(name: Name, private readonly isRequired?: boolean) {
     this[VariableName] = name
   }
@@ -76,6 +78,7 @@ class $Field<Name extends string, Type, Vars = {}> {
 }
 
 class $Base<Name extends string> {
+  // @ts-ignore
   constructor(private $$name: Name) {}
 
   protected $_select<Key extends string>(
@@ -86,11 +89,17 @@ class $Base<Name extends string> {
   }
 }
 
-class $Union<T, Name extends String> {
-  private type!: T
-  private name!: Name
+// @ts-ignore
+class $Union<T, Name extends String> extends $Base<Name> {
+  // @ts-ignore
+  private $$type!: T
+  // @ts-ignore
+  private $$name!: Name
 
-  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }) {}
+  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
+    super($$name)
+  }
+
   $on<Type extends keyof T, Sel extends Selection<T[Type]>>(
     alternative: Type,
     selectorFn: (selector: T[Type]) => [...Sel]
@@ -101,9 +110,12 @@ class $Union<T, Name extends String> {
   }
 }
 
+// @ts-ignore
 class $Interface<T, Name extends string> extends $Base<Name> {
-  private type!: T
-  private name!: Name
+  // @ts-ignore
+  private $$type!: T
+  // @ts-ignore
+  private $$name!: Name
 
   constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
     super($$name)
@@ -120,6 +132,7 @@ class $Interface<T, Name extends string> extends $Base<Name> {
 
 class $UnionSelection<T, Vars> {
   public kind: 'union' = 'union'
+  // @ts-ignore
   private vars!: Vars
   constructor(public alternativeName: string, public alternativeSelection: Selection<T>) {}
 }
@@ -128,16 +141,22 @@ type Selection<_any> = ReadonlyArray<$Field<any, any, any> | $UnionSelection<any
 
 type NeverNever<T> = [T] extends [never] ? {} : T
 
-export type GetOutput<X extends Selection<any>> = UnionToIntersection<
-  {
-    [I in keyof X]: X[I] extends $Field<infer Name, infer Type, any> ? { [K in Name]: Type } : never
-  }[keyof X & number]
-> &
-  NeverNever<
+type Simplify<T> = { [K in keyof T]: T[K] } & {}
+
+export type GetOutput<X extends Selection<any>> = Simplify<
+  UnionToIntersection<
     {
-      [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? Type : never
+      [I in keyof X]: X[I] extends $Field<infer Name, infer Type, any>
+        ? { [K in Name]: Type }
+        : never
     }[keyof X & number]
-  >
+  > &
+    NeverNever<
+      {
+        [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? Type : never
+      }[keyof X & number]
+    >
+>
 
 type PossiblyOptionalVar<VName extends string, VType> = undefined extends VType
   ? { [key in VName]?: VType }
@@ -186,7 +205,7 @@ function getArgVarType(input: string): ArgVarType {
       }
     : null
 
-  const type = array ? arrRegex.exec(input)![1] : input
+  const type = array ? arrRegex.exec(input)![1]! : input
   const isRequired = type.endsWith('!')
 
   return {
@@ -227,12 +246,15 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
         return wrapped(
           Array.from(Object.entries(args))
             .map(([key, val]) => {
-              if (!argTypes[key]) {
+              let argTypeForKey = argTypes[key]
+              if (!argTypeForKey) {
                 throw new Error(`Argument type for ${key} not found`)
               }
-              const cleanType = argTypes[key].replace('[', '').replace(']', '').replace('!', '')
+              const cleanType = argTypeForKey.replace('[', '').replace(']', '').replace(/!/g, '')
               return (
-                key + ':' + stringifyArgs(val, $InputTypes[cleanType], getArgVarType(argTypes[key]))
+                key +
+                ':' +
+                stringifyArgs(val, $InputTypes[cleanType]!, getArgVarType(argTypeForKey))
               )
             })
             .join(',')
@@ -309,6 +331,19 @@ export type OutputTypeOf<T> = T extends $Base<any>
   ? OutputTypeOf<Inner>
   : [T] extends [(args: any, selFn: (arg: infer Inner) => any) => any]
   ? OutputTypeOf<Inner>
+  : never
+
+export type QueryOutputType<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
+  infer Out
+>
+  ? Out
+  : never
+
+export type QueryInputType<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
+  any,
+  infer In
+>
+  ? In
   : never
 
 export function fragment<T, Sel extends Selection<T>>(
@@ -28678,38 +28713,65 @@ export type subscription = subscription_root
   
 
 export function query<Sel extends Selection<$RootTypes.query>>(
+  name: string,
   selectFn: (q: $RootTypes.query) => [...Sel]
-) {
+): TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+export function query<Sel extends Selection<$RootTypes.query>>(
+  selectFn: (q: $RootTypes.query) => [...Sel]
+): TypedDocumentNode<GetOutput<Sel>, Simplify<GetVariables<Sel>>>
+export function query<Sel extends Selection<$RootTypes.query>>(name: any, selectFn?: any) {
+  if (!selectFn) {
+    selectFn = name
+    name = ''
+  }
   let field = new $Field<'query', GetOutput<Sel>, GetVariables<Sel>>('query', {
     selection: selectFn(new $Root.query()),
   })
-  const str = fieldToQuery('query', field)
+  const str = fieldToQuery(`query ${name}`, field)
 
-  return gql(str) as any as TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+  return gql(str) as any
 }
 
 
 export function mutation<Sel extends Selection<$RootTypes.mutation>>(
+  name: string,
   selectFn: (q: $RootTypes.mutation) => [...Sel]
-) {
+): TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+export function mutation<Sel extends Selection<$RootTypes.mutation>>(
+  selectFn: (q: $RootTypes.mutation) => [...Sel]
+): TypedDocumentNode<GetOutput<Sel>, Simplify<GetVariables<Sel>>>
+export function mutation<Sel extends Selection<$RootTypes.query>>(name: any, selectFn?: any) {
+  if (!selectFn) {
+    selectFn = name
+    name = ''
+  }
   let field = new $Field<'mutation', GetOutput<Sel>, GetVariables<Sel>>('mutation', {
     selection: selectFn(new $Root.mutation()),
   })
-  const str = fieldToQuery('mutation', field)
+  const str = fieldToQuery(`mutation ${name}`, field)
 
-  return gql(str) as any as TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+  return gql(str) as any
 }
 
 
 export function subscription<Sel extends Selection<$RootTypes.subscription>>(
+  name: string,
   selectFn: (q: $RootTypes.subscription) => [...Sel]
-) {
+): TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+export function subscription<Sel extends Selection<$RootTypes.subscription>>(
+  selectFn: (q: $RootTypes.subscription) => [...Sel]
+): TypedDocumentNode<GetOutput<Sel>, Simplify<GetVariables<Sel>>>
+export function subscription<Sel extends Selection<$RootTypes.query>>(name: any, selectFn?: any) {
+  if (!selectFn) {
+    selectFn = name
+    name = ''
+  }
   let field = new $Field<'subscription', GetOutput<Sel>, GetVariables<Sel>>('subscription', {
     selection: selectFn(new $Root.subscription()),
   })
-  const str = fieldToQuery('subscription', field)
+  const str = fieldToQuery(`subscription ${name}`, field)
 
-  return gql(str) as any as TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+  return gql(str) as any
 }
 
 

--- a/examples/zeus.ts
+++ b/examples/zeus.ts
@@ -1,6 +1,6 @@
 
 
-import { TypedDocumentNode } from '@graphql-typed-document-node/core'
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
 import { gql } from 'graphql-tag'
 
 /* tslint:disable */
@@ -10,8 +10,10 @@ const VariableName = ' $1fcbcbff-3e78-462f-b45c-668a3e09bfd8'
 
 class Variable<T, Name extends string> {
   private [VariableName]: Name
+  // @ts-ignore
   private _type?: T
 
+  // @ts-ignore
   constructor(name: Name, private readonly isRequired?: boolean) {
     this[VariableName] = name
   }
@@ -76,6 +78,7 @@ class $Field<Name extends string, Type, Vars = {}> {
 }
 
 class $Base<Name extends string> {
+  // @ts-ignore
   constructor(private $$name: Name) {}
 
   protected $_select<Key extends string>(
@@ -86,11 +89,17 @@ class $Base<Name extends string> {
   }
 }
 
-class $Union<T, Name extends String> {
-  private type!: T
-  private name!: Name
+// @ts-ignore
+class $Union<T, Name extends String> extends $Base<Name> {
+  // @ts-ignore
+  private $$type!: T
+  // @ts-ignore
+  private $$name!: Name
 
-  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }) {}
+  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
+    super($$name)
+  }
+
   $on<Type extends keyof T, Sel extends Selection<T[Type]>>(
     alternative: Type,
     selectorFn: (selector: T[Type]) => [...Sel]
@@ -101,9 +110,12 @@ class $Union<T, Name extends String> {
   }
 }
 
+// @ts-ignore
 class $Interface<T, Name extends string> extends $Base<Name> {
-  private type!: T
-  private name!: Name
+  // @ts-ignore
+  private $$type!: T
+  // @ts-ignore
+  private $$name!: Name
 
   constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
     super($$name)
@@ -120,6 +132,7 @@ class $Interface<T, Name extends string> extends $Base<Name> {
 
 class $UnionSelection<T, Vars> {
   public kind: 'union' = 'union'
+  // @ts-ignore
   private vars!: Vars
   constructor(public alternativeName: string, public alternativeSelection: Selection<T>) {}
 }
@@ -128,16 +141,22 @@ type Selection<_any> = ReadonlyArray<$Field<any, any, any> | $UnionSelection<any
 
 type NeverNever<T> = [T] extends [never] ? {} : T
 
-export type GetOutput<X extends Selection<any>> = UnionToIntersection<
-  {
-    [I in keyof X]: X[I] extends $Field<infer Name, infer Type, any> ? { [K in Name]: Type } : never
-  }[keyof X & number]
-> &
-  NeverNever<
+type Simplify<T> = { [K in keyof T]: T[K] } & {}
+
+export type GetOutput<X extends Selection<any>> = Simplify<
+  UnionToIntersection<
     {
-      [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? Type : never
+      [I in keyof X]: X[I] extends $Field<infer Name, infer Type, any>
+        ? { [K in Name]: Type }
+        : never
     }[keyof X & number]
-  >
+  > &
+    NeverNever<
+      {
+        [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? Type : never
+      }[keyof X & number]
+    >
+>
 
 type PossiblyOptionalVar<VName extends string, VType> = undefined extends VType
   ? { [key in VName]?: VType }
@@ -186,7 +205,7 @@ function getArgVarType(input: string): ArgVarType {
       }
     : null
 
-  const type = array ? arrRegex.exec(input)![1] : input
+  const type = array ? arrRegex.exec(input)![1]! : input
   const isRequired = type.endsWith('!')
 
   return {
@@ -227,12 +246,15 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
         return wrapped(
           Array.from(Object.entries(args))
             .map(([key, val]) => {
-              if (!argTypes[key]) {
+              let argTypeForKey = argTypes[key]
+              if (!argTypeForKey) {
                 throw new Error(`Argument type for ${key} not found`)
               }
-              const cleanType = argTypes[key].replace('[', '').replace(']', '').replace('!', '')
+              const cleanType = argTypeForKey.replace('[', '').replace(']', '').replace(/!/g, '')
               return (
-                key + ':' + stringifyArgs(val, $InputTypes[cleanType], getArgVarType(argTypes[key]))
+                key +
+                ':' +
+                stringifyArgs(val, $InputTypes[cleanType]!, getArgVarType(argTypeForKey))
               )
             })
             .join(',')
@@ -309,6 +331,19 @@ export type OutputTypeOf<T> = T extends $Base<any>
   ? OutputTypeOf<Inner>
   : [T] extends [(args: any, selFn: (arg: infer Inner) => any) => any]
   ? OutputTypeOf<Inner>
+  : never
+
+export type QueryOutputType<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
+  infer Out
+>
+  ? Out
+  : never
+
+export type QueryInputType<T extends TypedDocumentNode<any>> = T extends TypedDocumentNode<
+  any,
+  infer In
+>
+  ? In
   : never
 
 export function fragment<T, Sel extends Selection<T>>(
@@ -513,7 +548,7 @@ export type JSON = string
 
 export class ChangeCard extends $Union<{SpecialCard: SpecialCard,EffectCard: EffectCard,Nameable: Nameable}, "ChangeCard"> {
   constructor() {
-    super({SpecialCard: SpecialCard,EffectCard: EffectCard,Nameable: Nameable})
+    super({SpecialCard: SpecialCard,EffectCard: EffectCard,Nameable: Nameable}, "ChangeCard")
   }
 }
 
@@ -522,6 +557,11 @@ export class Nameable extends $Interface<{CardStack: CardStack,Card: Card,Specia
   constructor() {
     super({CardStack: CardStack,Card: Card,SpecialCard: SpecialCard,EffectCard: EffectCard}, "Nameable")
   }
+  
+      
+      get name(): $Field<"name", string>  {
+       return this.$_select("name") as any
+      }
 }
 
 
@@ -762,38 +802,65 @@ export type subscription = Subscription
   
 
 export function query<Sel extends Selection<$RootTypes.query>>(
+  name: string,
   selectFn: (q: $RootTypes.query) => [...Sel]
-) {
+): TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+export function query<Sel extends Selection<$RootTypes.query>>(
+  selectFn: (q: $RootTypes.query) => [...Sel]
+): TypedDocumentNode<GetOutput<Sel>, Simplify<GetVariables<Sel>>>
+export function query<Sel extends Selection<$RootTypes.query>>(name: any, selectFn?: any) {
+  if (!selectFn) {
+    selectFn = name
+    name = ''
+  }
   let field = new $Field<'query', GetOutput<Sel>, GetVariables<Sel>>('query', {
     selection: selectFn(new $Root.query()),
   })
-  const str = fieldToQuery('query', field)
+  const str = fieldToQuery(`query ${name}`, field)
 
-  return gql(str) as any as TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+  return gql(str) as any
 }
 
 
 export function mutation<Sel extends Selection<$RootTypes.mutation>>(
+  name: string,
   selectFn: (q: $RootTypes.mutation) => [...Sel]
-) {
+): TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+export function mutation<Sel extends Selection<$RootTypes.mutation>>(
+  selectFn: (q: $RootTypes.mutation) => [...Sel]
+): TypedDocumentNode<GetOutput<Sel>, Simplify<GetVariables<Sel>>>
+export function mutation<Sel extends Selection<$RootTypes.query>>(name: any, selectFn?: any) {
+  if (!selectFn) {
+    selectFn = name
+    name = ''
+  }
   let field = new $Field<'mutation', GetOutput<Sel>, GetVariables<Sel>>('mutation', {
     selection: selectFn(new $Root.mutation()),
   })
-  const str = fieldToQuery('mutation', field)
+  const str = fieldToQuery(`mutation ${name}`, field)
 
-  return gql(str) as any as TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+  return gql(str) as any
 }
 
 
 export function subscription<Sel extends Selection<$RootTypes.subscription>>(
+  name: string,
   selectFn: (q: $RootTypes.subscription) => [...Sel]
-) {
+): TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+export function subscription<Sel extends Selection<$RootTypes.subscription>>(
+  selectFn: (q: $RootTypes.subscription) => [...Sel]
+): TypedDocumentNode<GetOutput<Sel>, Simplify<GetVariables<Sel>>>
+export function subscription<Sel extends Selection<$RootTypes.query>>(name: any, selectFn?: any) {
+  if (!selectFn) {
+    selectFn = name
+    name = ''
+  }
   let field = new $Field<'subscription', GetOutput<Sel>, GetVariables<Sel>>('subscription', {
     selection: selectFn(new $Root.subscription()),
   })
-  const str = fieldToQuery('subscription', field)
+  const str = fieldToQuery(`subscription ${name}`, field)
 
-  return gql(str) as any as TypedDocumentNode<GetOutput<Sel>, GetVariables<Sel>>
+  return gql(str) as any
 }
 
 

--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -3,7 +3,7 @@ let $InputTypes: { [key: string]: { [key: string]: string } } = {}
 let $Enums = new Set()
 
 /* BEGIN PREAMBLE */
-import { TypedDocumentNode } from '@graphql-typed-document-node/core'
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
 import { gql } from 'graphql-tag'
 
 /* tslint:disable */

--- a/test/examples/verify.ts
+++ b/test/examples/verify.ts
@@ -1,4 +1,4 @@
-import { TypedDocumentNode } from '@graphql-typed-document-node/core'
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
 import { print, parse, validate, buildSchema } from 'graphql'
 import fs from 'fs'
 import path from 'path'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,7 +52,7 @@
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    "importsNotUsedAsValues": "error" /* Specify emit/checking behavior for imports that are only used for types */,
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */


### PR DESCRIPTION
This pull request fixes a problem when building with Vite caused by TypedDocumentNode being imported as a value instead of as type. It also enables the `importsNotUsedAsValues` compiler option to prevent such a problem in the future.

![chrome_hOW4XeOdp8](https://user-images.githubusercontent.com/7276601/232842004-96b2c826-5bcb-4da3-a88f-ebd90281a643.png)

![Code_1XGnEUCbOc](https://user-images.githubusercontent.com/7276601/232842010-02f551a8-1b37-4e8a-b5d0-76184ff2462a.png)
