### PR TITLE
Export $Base and $Field classes

### DIFF
--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -85,7 +85,7 @@ type SelectOptions = {
   selection?: Selection<any>
 }
 
-class $Field<Name extends string, Type, Vars = {}> {
+export class $Field<Name extends string, Type, Vars = {}> {
   public kind: 'field' = 'field'
   public type!: Type
 
@@ -101,7 +101,7 @@ class $Field<Name extends string, Type, Vars = {}> {
   }
 }
 
-class $Base<Name extends string> {
+export class $Base<Name extends string> {
   // @ts-ignore
   constructor(private $$name: Name) {}
 


### PR DESCRIPTION
I've introduced a utility function `all` which allows for adding all fields while retaining proper typing on the query response.  I'd be happy to open a full PR with that functionality; alternatively, this very lightweight PR would allow access to the necessary typings.

**Do this:**
```
query(q => [
	q.items(all),
])
```

**Instead of:**
```
query(q => [
	q.items(i => [
		i.field1,
		i.field2,
		i.field3,
		i.field4,
		i.field5,
	]),
])
```

