### PR TITLE
Simplify return type of `all` function

### DIFF
--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -384,25 +384,13 @@ export function fragment<T, Sel extends Selection<T>>(
   return selectFn(new GQLType())
 }
 
-type LastOf<T> = UnionToIntersection<T extends any ? () => T : never> extends () => infer R
-  ? R
-  : never
-
-// TS4.0+
-type Push<T extends any[], V> = [...T, V]
-
-// TS4.1+
-type TuplifyUnion<T, L = LastOf<T>, N = [T] extends [never] ? true : false> = true extends N
-  ? []
-  : Push<TuplifyUnion<Exclude<T, L>>, L>
-
 type AllFieldProperties<I> = {
   [K in keyof I]: I[K] extends $Field<infer Name, infer Type, any> ? $Field<Name, Type, any> : never
 }
 
 type ValueOf<T> = T[keyof T]
 
-export type AllFields<T> = TuplifyUnion<ValueOf<AllFieldProperties<T>>>
+export type AllFields<T> = ValueOf<AllFieldProperties<T>>[]
 
 export function all<I extends $Base<any>>(instance: I) {
   const prototype = Object.getPrototypeOf(instance)


### PR DESCRIPTION
For models with more than ~30 fields, the `all` function gets a Typescript error:

`Type instantiation is excessively deep and possibly infinite`

This is due to the conversion of the union of fields to a tuple. I've reached out to the creator of #64 (@michaelbridge) and we agreed that nothing jumps out to us for a reason why this needs to be a tuple compared to just an array of fields.

To resolve, I've simplified the return result to just be an array of fields for the model.