### PR TITLE
fix: incorrectly inferred index type

### DIFF
--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -198,6 +198,7 @@ type ExtractInputVariables<Inputs> = Inputs extends Variable<infer VType, infer 
   // Avoid generating an index signature for possibly undefined or null inputs.
   // The compiler incorrectly infers null or undefined, and we must force access the Inputs
   // type to convince the compiler its "never", while still retaining {} as the result
+  // for null and undefined cases
   // Works around issue 79
   : Inputs extends (null | undefined)
   ? { [K in keyof Inputs]: Inputs[K] }

--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -44,7 +44,7 @@ type VariableWithoutScalars<T, Str extends string> = Variable<UnwrapCustomScalar
 // https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
 type VariabledInput<T> = [T] extends [CustomScalar<infer S> | null | undefined]
   ? // scalars only support variable input
-    Variable<S | null | undefined, any> | AllowedInlineScalars<S> | null | undefined
+  Variable<S | null | undefined, any> | AllowedInlineScalars<S> | null | undefined
   : [T] extends [CustomScalar<infer S>]
   ? Variable<S, any> | AllowedInlineScalars<S>
   : [T] extends [$Atomic]
@@ -53,11 +53,11 @@ type VariabledInput<T> = [T] extends [CustomScalar<infer S> | null | undefined]
   ? VariableWithoutScalars<T, any> | T | ArrayInput<I>
   : T extends Record<string, any> | null | undefined
   ?
-      | VariableWithoutScalars<T | null | undefined, any>
-      | null
-      | undefined
-      | { [K in keyof T]: VariabledInput<T[K]> }
-      | T
+  | VariableWithoutScalars<T | null | undefined, any>
+  | null
+  | undefined
+  | { [K in keyof T]: VariabledInput<T[K]> }
+  | T
   : T extends Record<string, any>
   ? VariableWithoutScalars<T, any> | { [K in keyof T]: VariabledInput<T[K]> } | T
   : never
@@ -97,7 +97,7 @@ class $Field<Name extends string, Type, Vars = {}> {
   public vars!: Vars
   public alias: string | null = null
 
-  constructor(public name: Name, public options: SelectOptions) {}
+  constructor(public name: Name, public options: SelectOptions) { }
 
   as<Rename extends string>(alias: Rename): $Field<Rename, Type, Vars> {
     const f = new $Field(this.name, this.options)
@@ -108,7 +108,7 @@ class $Field<Name extends string, Type, Vars = {}> {
 
 class $Base<Name extends string> {
   // @ts-ignore
-  constructor(private $$name: Name) {}
+  constructor(private $$name: Name) { }
 
   protected $_select<Key extends string>(
     name: Key,
@@ -125,7 +125,7 @@ class $Union<T, Name extends String> extends $Base<Name> {
   // @ts-ignore
   private $$name!: Name
 
-  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
+  constructor(private selectorClasses: { [K in keyof T]: { new(): T[K] } }, $$name: Name) {
     super($$name)
   }
 
@@ -146,7 +146,7 @@ class $Interface<T, Name extends string> extends $Base<Name> {
   // @ts-ignore
   private $$name!: Name
 
-  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
+  constructor(private selectorClasses: { [K in keyof T]: { new(): T[K] } }, $$name: Name) {
     super($$name)
   }
   $on<Type extends keyof T, Sel extends Selection<T[Type]>>(
@@ -163,7 +163,7 @@ class $UnionSelection<T, Vars> {
   public kind: 'union' = 'union'
   // @ts-ignore
   private vars!: Vars
-  constructor(public alternativeName: string, public alternativeSelection: Selection<T>) {}
+  constructor(public alternativeName: string, public alternativeSelection: Selection<T>) { }
 }
 
 type Selection<_any> = ReadonlyArray<$Field<any, any, any> | $UnionSelection<any, any>>
@@ -178,15 +178,15 @@ export type GetOutput<X extends Selection<any>> = Simplify<
   UnionToIntersection<
     {
       [I in keyof X]: X[I] extends $Field<infer Name, infer Type, any>
-        ? { [K in Name]: LeafType<Type> }
-        : never
+      ? { [K in Name]: LeafType<Type> }
+      : never
     }[keyof X & number]
   > &
-    NeverNever<
-      {
-        [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? LeafType<Type> : never
-      }[keyof X & number]
-    >
+  NeverNever<
+    {
+      [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? LeafType<Type> : never
+    }[keyof X & number]
+  >
 >
 
 type PossiblyOptionalVar<VName extends string, VType> = undefined extends VType
@@ -195,21 +195,27 @@ type PossiblyOptionalVar<VName extends string, VType> = undefined extends VType
 
 type ExtractInputVariables<Inputs> = Inputs extends Variable<infer VType, infer VName>
   ? PossiblyOptionalVar<VName, VType>
+  // Avoid generating an index signature for possibly undefined or null inputs.
+  // The compiler incorrectly infers null or undefined, and we must force access the Inputs
+  // type to convince the compiler its "never", while still retaining {} as the result
+  // Works around issue 79
+  : Inputs extends (null | undefined)
+  ? { [K in keyof Inputs]: Inputs[K] }
   : Inputs extends $Atomic
   ? {}
   : Inputs extends any[] | readonly any[]
   ? UnionToIntersection<
-      { [K in keyof Inputs]: ExtractInputVariables<Inputs[K]> }[keyof Inputs & number]
-    >
+    { [K in keyof Inputs]: ExtractInputVariables<Inputs[K]> }[keyof Inputs & number]
+  >
   : UnionToIntersection<{ [K in keyof Inputs]: ExtractInputVariables<Inputs[K]> }[keyof Inputs]>
 
 export type GetVariables<Sel extends Selection<any>, ExtraVars = {}> = UnionToIntersection<
   {
     [I in keyof Sel]: Sel[I] extends $Field<any, any, infer Vars>
-      ? Vars
-      : Sel[I] extends $UnionSelection<any, infer Vars>
-      ? Vars
-      : never
+    ? Vars
+    : Sel[I] extends $UnionSelection<any, infer Vars>
+    ? Vars
+    : never
   }[keyof Sel & number]
 > &
   ExtractInputVariables<ExtraVars>
@@ -232,8 +238,8 @@ const arrRegex = /\[(.*?)\]/
 function getArgVarType(input: string): ArgVarType {
   const array = input.includes('[')
     ? {
-        isRequired: input.endsWith('!'),
-      }
+      isRequired: input.endsWith('!'),
+    }
     : null
 
   const type = array ? arrRegex.exec(input)![1]! : input
@@ -379,7 +385,7 @@ export type QueryInputType<T extends TypedDocumentNode<any>> = T extends TypedDo
   : never
 
 export function fragment<T, Sel extends Selection<T>>(
-  GQLType: { new (): T },
+  GQLType: { new(): T },
   selectFn: (selector: T) => [...Sel]
 ) {
   return selectFn(new GQLType())
@@ -418,10 +424,10 @@ type ExactArgNames<GenericType, Constraint> = [Constraint] extends [$Atomic | Cu
   ? GenericType
   : Constraint extends ReadonlyArray<infer InnerConstraint>
   ? GenericType extends ReadonlyArray<infer Inner>
-    ? ReadonlyArray<ExactArgNames<Inner, InnerConstraint>>
-    : GenericType
+  ? ReadonlyArray<ExactArgNames<Inner, InnerConstraint>>
+  : GenericType
   : GenericType & {
-      [Key in keyof GenericType]: Key extends keyof Constraint
-        ? ExactArgNames<GenericType[Key], Constraint[Key]>
-        : never
-    }
+    [Key in keyof GenericType]: Key extends keyof Constraint
+    ? ExactArgNames<GenericType[Key], Constraint[Key]>
+    : never
+  }

--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -44,7 +44,7 @@ type VariableWithoutScalars<T, Str extends string> = Variable<UnwrapCustomScalar
 // https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
 type VariabledInput<T> = [T] extends [CustomScalar<infer S> | null | undefined]
   ? // scalars only support variable input
-  Variable<S | null | undefined, any> | AllowedInlineScalars<S> | null | undefined
+    Variable<S | null | undefined, any> | AllowedInlineScalars<S> | null | undefined
   : [T] extends [CustomScalar<infer S>]
   ? Variable<S, any> | AllowedInlineScalars<S>
   : [T] extends [$Atomic]
@@ -53,11 +53,11 @@ type VariabledInput<T> = [T] extends [CustomScalar<infer S> | null | undefined]
   ? VariableWithoutScalars<T, any> | T | ArrayInput<I>
   : T extends Record<string, any> | null | undefined
   ?
-  | VariableWithoutScalars<T | null | undefined, any>
-  | null
-  | undefined
-  | { [K in keyof T]: VariabledInput<T[K]> }
-  | T
+      | VariableWithoutScalars<T | null | undefined, any>
+      | null
+      | undefined
+      | { [K in keyof T]: VariabledInput<T[K]> }
+      | T
   : T extends Record<string, any>
   ? VariableWithoutScalars<T, any> | { [K in keyof T]: VariabledInput<T[K]> } | T
   : never
@@ -97,7 +97,7 @@ class $Field<Name extends string, Type, Vars = {}> {
   public vars!: Vars
   public alias: string | null = null
 
-  constructor(public name: Name, public options: SelectOptions) { }
+  constructor(public name: Name, public options: SelectOptions) {}
 
   as<Rename extends string>(alias: Rename): $Field<Rename, Type, Vars> {
     const f = new $Field(this.name, this.options)
@@ -108,7 +108,7 @@ class $Field<Name extends string, Type, Vars = {}> {
 
 class $Base<Name extends string> {
   // @ts-ignore
-  constructor(private $$name: Name) { }
+  constructor(private $$name: Name) {}
 
   protected $_select<Key extends string>(
     name: Key,
@@ -125,7 +125,7 @@ class $Union<T, Name extends String> extends $Base<Name> {
   // @ts-ignore
   private $$name!: Name
 
-  constructor(private selectorClasses: { [K in keyof T]: { new(): T[K] } }, $$name: Name) {
+  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
     super($$name)
   }
 
@@ -146,7 +146,7 @@ class $Interface<T, Name extends string> extends $Base<Name> {
   // @ts-ignore
   private $$name!: Name
 
-  constructor(private selectorClasses: { [K in keyof T]: { new(): T[K] } }, $$name: Name) {
+  constructor(private selectorClasses: { [K in keyof T]: { new (): T[K] } }, $$name: Name) {
     super($$name)
   }
   $on<Type extends keyof T, Sel extends Selection<T[Type]>>(
@@ -163,7 +163,7 @@ class $UnionSelection<T, Vars> {
   public kind: 'union' = 'union'
   // @ts-ignore
   private vars!: Vars
-  constructor(public alternativeName: string, public alternativeSelection: Selection<T>) { }
+  constructor(public alternativeName: string, public alternativeSelection: Selection<T>) {}
 }
 
 type Selection<_any> = ReadonlyArray<$Field<any, any, any> | $UnionSelection<any, any>>
@@ -178,15 +178,15 @@ export type GetOutput<X extends Selection<any>> = Simplify<
   UnionToIntersection<
     {
       [I in keyof X]: X[I] extends $Field<infer Name, infer Type, any>
-      ? { [K in Name]: LeafType<Type> }
-      : never
+        ? { [K in Name]: LeafType<Type> }
+        : never
     }[keyof X & number]
   > &
-  NeverNever<
-    {
-      [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? LeafType<Type> : never
-    }[keyof X & number]
-  >
+    NeverNever<
+      {
+        [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? LeafType<Type> : never
+      }[keyof X & number]
+    >
 >
 
 type PossiblyOptionalVar<VName extends string, VType> = undefined extends VType
@@ -195,28 +195,28 @@ type PossiblyOptionalVar<VName extends string, VType> = undefined extends VType
 
 type ExtractInputVariables<Inputs> = Inputs extends Variable<infer VType, infer VName>
   ? PossiblyOptionalVar<VName, VType>
-  // Avoid generating an index signature for possibly undefined or null inputs.
+  : // Avoid generating an index signature for possibly undefined or null inputs.
   // The compiler incorrectly infers null or undefined, and we must force access the Inputs
   // type to convince the compiler its "never", while still retaining {} as the result
   // for null and undefined cases
   // Works around issue 79
-  : Inputs extends (null | undefined)
+  Inputs extends null | undefined
   ? { [K in keyof Inputs]: Inputs[K] }
   : Inputs extends $Atomic
   ? {}
   : Inputs extends any[] | readonly any[]
   ? UnionToIntersection<
-    { [K in keyof Inputs]: ExtractInputVariables<Inputs[K]> }[keyof Inputs & number]
-  >
+      { [K in keyof Inputs]: ExtractInputVariables<Inputs[K]> }[keyof Inputs & number]
+    >
   : UnionToIntersection<{ [K in keyof Inputs]: ExtractInputVariables<Inputs[K]> }[keyof Inputs]>
 
 export type GetVariables<Sel extends Selection<any>, ExtraVars = {}> = UnionToIntersection<
   {
     [I in keyof Sel]: Sel[I] extends $Field<any, any, infer Vars>
-    ? Vars
-    : Sel[I] extends $UnionSelection<any, infer Vars>
-    ? Vars
-    : never
+      ? Vars
+      : Sel[I] extends $UnionSelection<any, infer Vars>
+      ? Vars
+      : never
   }[keyof Sel & number]
 > &
   ExtractInputVariables<ExtraVars>
@@ -239,8 +239,8 @@ const arrRegex = /\[(.*?)\]/
 function getArgVarType(input: string): ArgVarType {
   const array = input.includes('[')
     ? {
-      isRequired: input.endsWith('!'),
-    }
+        isRequired: input.endsWith('!'),
+      }
     : null
 
   const type = array ? arrRegex.exec(input)![1]! : input
@@ -386,7 +386,7 @@ export type QueryInputType<T extends TypedDocumentNode<any>> = T extends TypedDo
   : never
 
 export function fragment<T, Sel extends Selection<T>>(
-  GQLType: { new(): T },
+  GQLType: { new (): T },
   selectFn: (selector: T) => [...Sel]
 ) {
   return selectFn(new GQLType())
@@ -425,10 +425,10 @@ type ExactArgNames<GenericType, Constraint> = [Constraint] extends [$Atomic | Cu
   ? GenericType
   : Constraint extends ReadonlyArray<infer InnerConstraint>
   ? GenericType extends ReadonlyArray<infer Inner>
-  ? ReadonlyArray<ExactArgNames<Inner, InnerConstraint>>
-  : GenericType
+    ? ReadonlyArray<ExactArgNames<Inner, InnerConstraint>>
+    : GenericType
   : GenericType & {
-    [Key in keyof GenericType]: Key extends keyof Constraint
-    ? ExactArgNames<GenericType[Key], Constraint[Key]>
-    : never
-  }
+      [Key in keyof GenericType]: Key extends keyof Constraint
+        ? ExactArgNames<GenericType[Key], Constraint[Key]>
+        : never
+    }

--- a/test/examples/test-countries.good.ts
+++ b/test/examples/test-countries.good.ts
@@ -71,9 +71,7 @@ query MyName($test: ID!) {
 }
 `
 
-let allQuery = query('AllFields', q => [
-  q.countries(all),
-])
+let allQuery = query('AllFields', q => [q.countries(all)])
 
 let allQueryString = `
 query AllFields {
@@ -92,10 +90,7 @@ query AllFields {
 `
 
 let nestedAllQuery = query('NestedAllFields', q => [
-  q.countries(c => [
-    c.capital,
-    c.languages(all),
-  ]),
+  q.countries(c => [c.capital, c.languages(all)]),
 ])
 
 let nestedAllQueryString = `
@@ -114,10 +109,7 @@ query NestedAllFields {
 `
 
 let doubleAllQuery = query('DoubleAllFields', q => [
-  q.countries(c => [
-    ...all(c),
-    c.languages(all),
-  ]),
+  q.countries(c => [...all(c), c.languages(all)]),
 ])
 
 let doubleAllQueryString = `
@@ -144,7 +136,7 @@ query DoubleAllFields {
 `
 
 let filterVariableQuery = query('FilterVariable', q => [
-  q.countries({filter: $('filter')}, c => [c.capital, c.code])
+  q.countries({ filter: $('filter') }, c => [c.capital, c.code]),
 ])
 
 let filterVariableQueryString = `

--- a/test/examples/test-countries.good.ts
+++ b/test/examples/test-countries.good.ts
@@ -71,7 +71,9 @@ query MyName($test: ID!) {
 }
 `
 
-let allQuery = query('AllFields', q => [q.countries(all)])
+let allQuery = query('AllFields', q => [
+  q.countries(all),
+])
 
 let allQueryString = `
 query AllFields {
@@ -90,7 +92,10 @@ query AllFields {
 `
 
 let nestedAllQuery = query('NestedAllFields', q => [
-  q.countries(c => [c.capital, c.languages(all)]),
+  q.countries(c => [
+    c.capital,
+    c.languages(all),
+  ]),
 ])
 
 let nestedAllQueryString = `
@@ -109,7 +114,10 @@ query NestedAllFields {
 `
 
 let doubleAllQuery = query('DoubleAllFields', q => [
-  q.countries(c => [...all(c), c.languages(all)]),
+  q.countries(c => [
+    ...all(c),
+    c.languages(all),
+  ]),
 ])
 
 let doubleAllQueryString = `
@@ -136,7 +144,7 @@ query DoubleAllFields {
 `
 
 let filterVariableQuery = query('FilterVariable', q => [
-  q.countries({ filter: $('filter') }, c => [c.capital, c.code]),
+  q.countries({filter: $('filter')}, c => [c.capital, c.code])
 ])
 
 let filterVariableQueryString = `

--- a/test/examples/test-x.good.ts
+++ b/test/examples/test-x.good.ts
@@ -1,7 +1,8 @@
 // Todo: add big query tests
 
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { verify } from './verify'
-import { query, order_by, $, $$, mutation } from './x.graphql.api'
+import { query, order_by, $, $$, mutation, GetVariables } from './x.graphql.api'
 
 let orderByTest = query(q => [
   q.bookings(
@@ -16,6 +17,12 @@ let orderByTest = query(q => [
     },
     o => [o.id, o.guestName, o.nights, o.bookerName]
   ),
+])
+
+
+let genericWhere = query(q => [
+  // does not seem to generate the correct variable type
+  q.aggregateBookings({ where: $('where') }, a => [a.aggregate(a => [a.count(a.count)])])
 ])
 
 let bookingsBetween = query(q => [
@@ -122,5 +129,15 @@ export default [
     },
     schemaPath: 'x.graphql',
     string: nullableArgumentString,
+  }),
+
+  verify({
+    query: genericWhere,
+    variables: {
+      where: {
+        createdAt: { _eq: '2024-01-01' },
+      },
+    },
+    schemaPath: 'x.graphql',
   }),
 ]

--- a/test/examples/test-x.good.ts
+++ b/test/examples/test-x.good.ts
@@ -1,6 +1,3 @@
-// Todo: add big query tests
-
-import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { verify } from './verify'
 import { query, order_by, $, $$, mutation } from './x.graphql.api'
 
@@ -24,26 +21,6 @@ let genericWhere = query(q => [
   // does not seem to generate the correct variable type
   q.aggregateBookings({ where: $('where') }, a => [a.aggregate(a => [a.count(a.count)])])
 ])
-
-type GetInputOfTypedDocumentNode<T extends TypedDocumentNode<any, any>> = T extends TypedDocumentNode<any, infer Input> ? Input : never
-
-type InputOfGenericWhere = GetInputOfTypedDocumentNode<typeof genericWhere>
-
-let example1: InputOfGenericWhere = {
-  where: {
-    createdAt: {
-      _eq: '2024-01-01'
-    }
-  }
-}
-
-type InputDotWhere = typeof example1.where
-
-let example2: InputDotWhere = {
-  createdAt: {
-    _eq: '2024-01-01'
-  }
-}
 
 
 let bookingsBetween = query(q => [

--- a/test/examples/test-x.good.ts
+++ b/test/examples/test-x.good.ts
@@ -37,9 +37,9 @@ let example1: InputOfGenericWhere = {
   }
 }
 
-type xdotwhere = typeof example1.where
+type InputDotWhere = typeof example1.where
 
-let example2: xdotwhere = {
+let example2: InputDotWhere = {
   createdAt: {
     _eq: '2024-01-01'
   }

--- a/test/examples/test-x.good.ts
+++ b/test/examples/test-x.good.ts
@@ -2,7 +2,7 @@
 
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { verify } from './verify'
-import { query, order_by, $, $$, mutation, GetVariables } from './x.graphql.api'
+import { query, order_by, $, $$, mutation } from './x.graphql.api'
 
 let orderByTest = query(q => [
   q.bookings(
@@ -24,6 +24,19 @@ let genericWhere = query(q => [
   // does not seem to generate the correct variable type
   q.aggregateBookings({ where: $('where') }, a => [a.aggregate(a => [a.count(a.count)])])
 ])
+
+type GetInputOfTypedDocumentNode<T extends TypedDocumentNode<any, any>> = T extends TypedDocumentNode<any, infer Input> ? Input : never
+
+type InputOfGenericWhere = GetInputOfTypedDocumentNode<typeof genericWhere>
+
+declare let x: InputOfGenericWhere
+
+type xdotwhere = NonNullable<typeof x.where>
+
+declare let y: xdotwhere;
+
+type ydotcreatedAt = typeof y.createdAt
+
 
 let bookingsBetween = query(q => [
   q.bookings(

--- a/test/examples/test-x.good.ts
+++ b/test/examples/test-x.good.ts
@@ -16,12 +16,10 @@ let orderByTest = query(q => [
   ),
 ])
 
-
 let genericWhere = query(q => [
   // does not seem to generate the correct variable type
-  q.aggregateBookings({ where: $('where') }, a => [a.aggregate(a => [a.count(a.count)])])
+  q.aggregateBookings({ where: $('where') }, a => [a.aggregate(a => [a.count(a.count)])]),
 ])
-
 
 let bookingsBetween = query(q => [
   q.bookings(

--- a/test/examples/test-x.good.ts
+++ b/test/examples/test-x.good.ts
@@ -29,8 +29,6 @@ type GetInputOfTypedDocumentNode<T extends TypedDocumentNode<any, any>> = T exte
 
 type InputOfGenericWhere = GetInputOfTypedDocumentNode<typeof genericWhere>
 
-declare let x: InputOfGenericWhere
-
 let example1: InputOfGenericWhere = {
   where: {
     createdAt: {
@@ -39,14 +37,13 @@ let example1: InputOfGenericWhere = {
   }
 }
 
-type xdotwhere = typeof x.where
+type xdotwhere = typeof example1.where
 
 let example2: xdotwhere = {
   createdAt: {
     _eq: '2024-01-01'
   }
 }
-
 
 
 let bookingsBetween = query(q => [

--- a/test/examples/test-x.good.ts
+++ b/test/examples/test-x.good.ts
@@ -31,11 +31,22 @@ type InputOfGenericWhere = GetInputOfTypedDocumentNode<typeof genericWhere>
 
 declare let x: InputOfGenericWhere
 
-type xdotwhere = NonNullable<typeof x.where>
+let example1: InputOfGenericWhere = {
+  where: {
+    createdAt: {
+      _eq: '2024-01-01'
+    }
+  }
+}
 
-declare let y: xdotwhere;
+type xdotwhere = typeof x.where
 
-type ydotcreatedAt = typeof y.createdAt
+let example2: xdotwhere = {
+  createdAt: {
+    _eq: '2024-01-01'
+  }
+}
+
 
 
 let bookingsBetween = query(q => [


### PR DESCRIPTION
In some cases where inputs can be possibly null or undefined, the compiler gets confused computing the distributive union for the conditional type and ends up generating an index signature for the variable types. This then proceeds to interfere with typechecking for the variables.

This fix works around the issue by forcing the compiler to "resolve" the type completely which typically makes it evaluate to never and disappear entirely - however, for the real null and undefined cases, we still effectively generate `{}` as it should be with other atomic types, preserving correctness.

Fixes #79 

side note: This does make me think that magically inferring variable types is too much for the compiler. A simpler design where

```typescript
query({myVariable: $.myType, otherVariable: $.Array($.anotherType)}, (q, $) => [
  q.someQuery({someInput: $.myVariable, otherInput: $.otherVariable})
])
```

might not be as flashy and convenient, but may be a better option that will significantly simplify the whole typing story, with `$.typename` syntax ensuring that autocomplete is still relatively convenient for selecting input types. But this would be a backward-incompatible change.