### PR TITLE
fix!: optional fields for nullability

### DIFF
--- a/src/compile-api.ts
+++ b/src/compile-api.ts
@@ -44,7 +44,7 @@ async function fetchOrRead(args: Args) {
           query: gq.getIntrospectionQuery(),
         }),
       })
-      let body = await res.body.json()
+      let body: any = await res.body.json()
       if (body.errors) {
         throw new UserFacingError(
           `Error introspecting schema from ${args.schema}: ${JSON.stringify(body.errors, null, 2)}`

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -156,10 +156,10 @@ export function compileSchemaDefinitions(
         return `${printTypeWrapped(wrappedType, wrapperDef.type, true)}`
       case gq.Kind.LIST_TYPE:
         return `Array<${printTypeWrapped(wrappedType, wrapperDef.type)}>${
-          !notNull ? ' | undefined' : ''
+          !notNull ? ' | null' : ''
         }`
       case gq.Kind.NAMED_TYPE:
-        return `${toTSTypeName(wrappedType)}${!notNull ? ' | undefined' : ''}`
+        return `${toTSTypeName(wrappedType)}${!notNull ? ' | null' : ''}`
     }
   }
 
@@ -168,9 +168,9 @@ export function compileSchemaDefinitions(
       case gq.Kind.NON_NULL_TYPE:
         return `${printType(def.type, true)}`
       case gq.Kind.LIST_TYPE:
-        return `Readonly<Array<${printType(def.type)}>>${!notNull ? ' | null | undefined' : ''}`
+        return `Readonly<Array<${printType(def.type)}>>${!notNull ? ' | null' : ''}`
       case gq.Kind.NAMED_TYPE:
-        return `${toTSTypeName(def.name.value)}${!notNull ? ' | null | undefined' : ''}`
+        return `${toTSTypeName(def.name.value)}${!notNull ? ' | null' : ''}`
     }
   }
 

--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -174,29 +174,22 @@ type Simplify<T> = { [K in keyof T]: T[K] } & {}
 
 type LeafType<T> = T extends CustomScalar<infer S> ? S : T
 
-/** Removes undefined from a type, preserving null. For selected fields. */
-type SelectedType<T> = Exclude<T, undefined>
-
 export type GetOutput<X extends Selection<any>> = Simplify<
   UnionToIntersection<
     {
       [I in keyof X]: X[I] extends $Field<infer Name, infer Type, any>
-        ? { [K in Name]: SelectedType<LeafType<Type>> }
+        ? { [K in Name]: LeafType<Type> }
         : never
     }[keyof X & number]
   > &
     NeverNever<
       {
-        [I in keyof X]: X[I] extends $UnionSelection<infer Type, any>
-          ? SelectedType<LeafType<Type>>
-          : never
+        [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? LeafType<Type> : never
       }[keyof X & number]
     >
 >
 
-type PossiblyOptionalVar<VName extends string, VType> = undefined extends VType
-  ? { [key in VName]?: VType }
-  : null extends VType
+type PossiblyOptionalVar<VName extends string, VType> = null extends VType
   ? { [key in VName]?: VType }
   : { [key in VName]: VType }
 
@@ -374,7 +367,7 @@ export type OutputTypeOf<T> = T extends $Interface<infer Subtypes, any>
   : T extends $Union<infer Subtypes, any>
   ? { [K in keyof Subtypes]: OutputTypeOf<Subtypes[K]> }[keyof Subtypes]
   : T extends $Base<any>
-  ? { [K in keyof T]?: OutputTypeOf<T[K]> }
+  ? { [K in keyof T]?: OutputTypeOf<T[K]> | null }
   : [T] extends [$Field<any, infer FieldType, any>]
   ? FieldType
   : [T] extends [(selFn: (arg: infer Inner) => any) => any]

--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -174,17 +174,22 @@ type Simplify<T> = { [K in keyof T]: T[K] } & {}
 
 type LeafType<T> = T extends CustomScalar<infer S> ? S : T
 
+/** Removes undefined from a type, preserving null. For selected fields. */
+type SelectedType<T> = Exclude<T, undefined>
+
 export type GetOutput<X extends Selection<any>> = Simplify<
   UnionToIntersection<
     {
       [I in keyof X]: X[I] extends $Field<infer Name, infer Type, any>
-        ? { [K in Name]: LeafType<Type> }
+        ? { [K in Name]: SelectedType<LeafType<Type>> }
         : never
     }[keyof X & number]
   > &
     NeverNever<
       {
-        [I in keyof X]: X[I] extends $UnionSelection<infer Type, any> ? LeafType<Type> : never
+        [I in keyof X]: X[I] extends $UnionSelection<infer Type, any>
+          ? SelectedType<LeafType<Type>>
+          : never
       }[keyof X & number]
     >
 >
@@ -430,6 +435,7 @@ export function all<I extends $Base<any>>(instance: I) {
 // We use a dummy conditional type that involves GenericType to defer the compiler's inference of
 // any possible variables nested in this type. This addresses a problem where variables are
 // inferred with type unknown
+// @ts-ignore
 type ExactArgNames<GenericType, Constraint> = GenericType extends never
   ? never
   : [Constraint] extends [$Atomic | CustomScalar<any>]

--- a/test/examples/nullability.graphql
+++ b/test/examples/nullability.graphql
@@ -1,0 +1,14 @@
+type Author {
+  id: Int!
+  name: String!
+}
+
+type Post {
+  id: Int!
+  title: String!
+  author: Author
+}
+
+type Query {
+  posts: [Post!]
+}

--- a/test/examples/test-nullability.good.ts
+++ b/test/examples/test-nullability.good.ts
@@ -1,0 +1,28 @@
+import { query } from './nullability.graphql.api'
+import { verify } from './verify'
+
+const basicQuery = query(q => [q.posts(p => [p.id, p.author(a => [a.name])])])
+
+export default [
+  verify({
+    query: basicQuery,
+    schemaPath: 'nullability.graphql',
+    variables: {},
+    useOutputType: output => {
+      let posts = output.posts
+      if (posts === null) {
+        return
+      }
+      let firstPost = posts[0]
+      if (firstPost === null) {
+        return
+      }
+      let author = firstPost.author
+      if (author === null) {
+        return
+      }
+      let name = author.name
+      return name + 'test'
+    },
+  }),
+]

--- a/test/examples/test-nullability.good.ts
+++ b/test/examples/test-nullability.good.ts
@@ -14,7 +14,8 @@ export default [
         return
       }
       let firstPost = posts[0]
-      if (firstPost === null) {
+      // Array access can be undefined.
+      if (firstPost === undefined) {
         return
       }
       let author = firstPost.author


### PR DESCRIPTION
This is a second implementation for https://github.com/typed-graphql-builder/typed-graphql-builder/issues/90 that also fixes the shape of input and output types by avoiding `undefined` in favor of optional fields.