### PR TITLE
feat: Add nameof function

### DIFF
--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -4,6 +4,7 @@ let $Enums = new Set()
 
 /* BEGIN PREAMBLE */
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
+import { gql } from 'graphql-tag'
 
 /* tslint:disable */
 /* eslint-disable */


### PR DESCRIPTION
Sometimes it is useful to be able to get the name of a gql interface or union type rather than the subtypes. 

For example to typecheck the arguments passed to the apollo client possible types - https://www.apollographql.com/docs/react/data/fragments#defining-possibletypes-manually

This utiltiy function allows the names of all the graphql types be typeconstrained