### PR TITLE
Fixes variables used in an array setting the input variable as array rather than the normal type

### DIFF
--- a/src/preamble.src.ts
+++ b/src/preamble.src.ts
@@ -280,7 +280,7 @@ function fieldToQuery(prefix: string, field: $Field<any, any, any>) {
           return '$' + argVarName
         }
         if (Array.isArray(args))
-          return '[' + args.map(arg => stringifyArgs(arg, argTypes, argVarType)).join(',') + ']'
+          return '[' + args.map(arg => stringifyArgs(arg, argTypes, argVarType && { ...argVarType, array: null })).join(',') + ']'
         const wrapped = (content: string) => (argVarType ? '{' + content + '}' : content)
         return wrapped(
           Array.from(Object.entries(args))
@@ -444,7 +444,7 @@ type ExactArgNames<GenericType, Constraint> = GenericType extends never
     }
 
 
-export type NameOf<T> = 
+export type NameOf<T> =
   T extends $Interface<any, infer Name>
   ? Name
   : T extends $Union<any, infer Name>


### PR DESCRIPTION
Fixes this issue:

```ts
query(q => [
  q.foo({ var: [$("var")], f => [....]),
]);
```

Being built as: 

```ts
query foo($var: [String]) {
  foo(var: [$var]) {}
}
```

when it should be:

```ts
query foo($var: String) {
  foo(var: [$var]) {}
}
```

(Notice type for $var should not be an array in this case, but it was being marked as one)